### PR TITLE
Move Memory Allocation in PF

### DIFF
--- a/src/progpy/state_estimators/particle_filter.py
+++ b/src/progpy/state_estimators/particle_filter.py
@@ -127,7 +127,6 @@ class ParticleFilter(state_estimator.StateEstimator):
         num_particles = self.parameters['num_particles']
         # Check which output keys are present (i.e., output of measurement function)
         measurement_keys = output(self.model.StateContainer({key: particles[key][0] for key in particles.keys()})).keys()
-        zPredicted = {key: empty(num_particles) for key in measurement_keys}
 
         if self.model.is_vectorized:
             # Propagate particles state
@@ -140,6 +139,8 @@ class ParticleFilter(state_estimator.StateEstimator):
             # Get particle measurements
             zPredicted = output(self.particles)
         else:
+            # Reserve space (for efficiency)
+            zPredicted = {key: empty(num_particles) for key in measurement_keys}
             # Propagate and calculate weights
             for i in range(num_particles):
                 t_i = self.t  # Used to mark time for each particle


### PR DESCRIPTION
Very Minor PR

Move line where we reserve the memory for the output into the non-vectorized conditional. This memory is not used in vectorized case. In that case we allocate the memory when calling output instead. This makes that case very slightly faster.

Identified this opportunity when debugging with @mstraut 