### PR TITLE
Function in Composite Model

### DIFF
--- a/examples/06_Combining_Models.ipynb
+++ b/examples/06_Combining_Models.ipynb
@@ -239,7 +239,7 @@
     "def future_loading(t, x=None):\n",
     "    return load\n",
     "\n",
-    "simulated_results = m_powertrain.simulate_to(2, future_loading, dt=2.5e-5, save_freq=1e-2)\n",
+    "simulated_results = m_powertrain.simulate_to(1, future_loading, dt=2.5e-5, save_freq=2e-2)\n",
     "fig = simulated_results.outputs.plot(compact=False, keys=['DCMotor.v_rot'], ylabel='Velocity')\n",
     "fig = simulated_results.states.plot(keys=['DCMotor.i_b', 'DCMotor.i_c', 'DCMotor.i_a'], ylabel='ESC Currents')"
    ]
@@ -258,7 +258,7 @@
    "outputs": [],
    "source": [
     "def torque_multiplier(t_l):\n",
-    "    return t_l * 1.0"
+    "    return t_l * 1.1"
    ]
   },
   {
@@ -304,7 +304,7 @@
     "        (m_esc, m_load, m_motor, torque_multiplier), \n",
     "        connections=connections,\n",
     "        outputs={'DCMotor.v_rot', 'DCMotor.theta'})\n",
-    "simulated_results = m_powertrain.simulate_to(2, future_loading, dt=2.5e-5, save_freq=1e-2)\n",
+    "simulated_results = m_powertrain.simulate_to(1, future_loading, dt=2.5e-5, save_freq=2e-2)\n",
     "fig = simulated_results.outputs.plot(compact=False, keys=['DCMotor.v_rot'], ylabel='Velocity')\n",
     "fig = simulated_results.states.plot(keys=['DCMotor.i_b', 'DCMotor.i_c', 'DCMotor.i_a'], ylabel='ESC Currents')"
    ]

--- a/examples/06_Combining_Models.ipynb
+++ b/examples/06_Combining_Models.ipynb
@@ -248,6 +248,78 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Note: A function can be used to perform simple transitions between models. For example, if you wanted to multiply the torque by 1.1 to represent some gearing or additional load, that could be done by defining a function, as follows"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def torque_multiplier(t_l):\n",
+    "    return t_l * 1.0"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The function is referred to as 'function' by the composite model. So we can add the function into the connections as follows. Note that the argument name is used for the input of the function and 'return' is used to signify the function's return value. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "connections = [\n",
+    "    ('PropellerLoad.t_l', 'function.t_l'),\n",
+    "    ('function.return', 'DCMotor.t_l')\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now let's add back in the other connections and build the composite model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "connections.extend([\n",
+    "    ('ESC.v_a', 'DCMotor.v_a'),\n",
+    "    ('ESC.v_b', 'DCMotor.v_b'),\n",
+    "    ('ESC.v_c', 'DCMotor.v_c'),\n",
+    "    ('DCMotor.theta', 'ESC.theta'),\n",
+    "    ('DCMotor.v_rot', 'PropellerLoad.v_rot')\n",
+    "])\n",
+    "m_powertrain = CompositeModel(\n",
+    "        (m_esc, m_load, m_motor, torque_multiplier), \n",
+    "        connections=connections,\n",
+    "        outputs={'DCMotor.v_rot', 'DCMotor.theta'})\n",
+    "simulated_results = m_powertrain.simulate_to(2, future_loading, dt=2.5e-5, save_freq=1e-2)\n",
+    "fig = simulated_results.outputs.plot(compact=False, keys=['DCMotor.v_rot'], ylabel='Velocity')\n",
+    "fig = simulated_results.states.plot(keys=['DCMotor.i_b', 'DCMotor.i_c', 'DCMotor.i_a'], ylabel='ESC Currents')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that you can also have functions with more than one argument. If you dont connect the arguments of the function to some model, it will show up in the inputs of the composite model."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Ensemble Model"
    ]
   },

--- a/src/progpy/composite_model.py
+++ b/src/progpy/composite_model.py
@@ -16,17 +16,17 @@ class CompositeModel(PrognosticsModel):
     A CompositeModel is a PrognosticsModel that is composed of multiple PrognosticsModels. This is a tool for modeling system-of-systems. I.e., interconnected systems, where the behavior and state of one system effects the state of another system. The composite prognostics models are connected using defined connections between the output or state of one model, and the input of another model. The resulting CompositeModel behaves as a single model.
 
     Args:
-        models (list[PrognosticsModel] or list[tuple[str, PrognosticsModel]]):
+        models ({list[{PrognosticsModel, function}], list[tuple[str, {PrognosticsModel, function}]]):
             A list of PrognosticsModels to be combined into a single model.
             Provided in one of two forms:
 
-            1. A list of PrognosticsModels. The name of each model will be the class name. A number will be added for duplicates
+            1. A list of PrognosticsModels or functions. The name of each model will be the class name for models or 'function' for functions. A number will be added for duplicates
 
-            2. A list of tuples where the first element is the model name and the second element is the model
+            2. A list of tuples where the first element is the model/function name and the second element is the model/function
 
             Note: Order provided will be the order that models are executed
         connections (list[tuple[str, str]], optional):
-            A list of tuples where the first element is the name of the output, state, or performance metrics of one model and the second element is the name of the input of another model.
+            A list of tuples where the first element is the name of the output, state, or performance metrics of one model or function return and the second element is the name of the input of another model or argument of a function.
             The first element of the tuple must be of the form "model_name.output_name", "model_name.state_name", or "model_name.performance_metric_key".
             The second element of the tuple must be of the form "model_name.input_name".
             For example, if you have two models, "Batt1" and "Batt2", and you want to connect the output of "Batt1" to the input of "Batt2", you would use the following connection: ("Batt1.output", "Batt2.input")

--- a/src/progpy/composite_model.py
+++ b/src/progpy/composite_model.py
@@ -2,6 +2,7 @@
 # National Aeronautics and Space Administration.  All Rights Reserved.
 
 from collections.abc import Iterable
+from inspect import signature
 
 from progpy import PrognosticsModel
 
@@ -40,7 +41,8 @@ class CompositeModel(PrognosticsModel):
         if not isinstance(models, Iterable):
             raise ValueError('The models argument must be a list')
         if len(models) <= 1:
-            raise ValueError('The models argument must contain at least two models')
+            raise ValueError(
+                'The models argument must contain at least two models')
         if not isinstance(connections, Iterable):
             raise ValueError('The connections argument must be a list')
 
@@ -53,38 +55,56 @@ class CompositeModel(PrognosticsModel):
         self.model_names = set()
         duplicate_names = {}
         kwargs['models'] = []
+        kwargs['functions'] = []
 
         # Handle models
         for m in models:
-            if isinstance(m, Iterable):
+            # Ensure tuple format
+            if isinstance(m, Iterable):  # Already a tuple
                 if len(m) != 2:
-                    raise ValueError('Each model tuple must be of the form (name: str, model). For example ("Batt1", BatteryElectroChem())')
+                    raise ValueError(
+                        'Each model tuple must be of the form '
+                        '(name: str, model). For example '
+                        '("Batt1", BatteryElectroChem())')
                 if not isinstance(m[0], str):
-                    raise ValueError('The first element of each model tuple must be a string')
-                if not isinstance(m[1], PrognosticsModel):
-                    raise ValueError('The second element of each model tuple must be a PrognosticsModel')
-                if m[0] in self.model_names:
-                    duplicate_names[m[0]] = duplicate_names.get(m[0], 1) + 1
-                    m = (m[0] + '_' + str(duplicate_names[m[0]]), m[1])
-                self.model_names.add(m[0])
-                kwargs['models'].append(m)
+                    raise ValueError(
+                        'The first element of each model tuple must'
+                        ' be a string')
             elif isinstance(m, PrognosticsModel):
                 m = (m.__class__.__name__, m)
-                if m[0] in self.model_names:
-                    duplicate_names[m[0]] = duplicate_names.get(m[0], 1) + 1
-                    m = (m[0] + '_' + str(duplicate_names[m[0]]), m[1])
-                self.model_names.add(m[0])
-                kwargs['models'].append(m)
+            elif callable(m):
+                m = ('function', m)
             else:
                 raise ValueError(f'Each model must be a PrognosticsModel or tuple (name: str, PrognosticsModel), was {type(m)}')
 
+            # Check for duplicate names
+            if m[0] in self.model_names:
+                duplicate_names[m[0]] = duplicate_names.get(m[0], 1) + 1
+                m = (m[0] + '_' + str(duplicate_names[m[0]]), m[1])
+            self.model_names.add(m[0])
+
+            # Handle model/function
+            if isinstance(m[1], PrognosticsModel):
+                kwargs['models'].append(m)
+            elif callable(m[1]):
+                kwargs['functions'].append(m)
+            else:
+                raise ValueError(
+                    'The second element of each model tuple must be a'
+                    ' PrognosticsModel')
+
+        # update inputs, states, outputs, etc.
         for (name, m) in kwargs['models']:
             self.inputs |= set([name + DIVIDER + u for u in m.inputs])
             self.states |= set([name + DIVIDER + x for x in m.states])
             self.outputs |= set([name + DIVIDER + z for z in m.outputs])
             self.events |= set([name + DIVIDER + e for e in m.events])
             self.performance_metric_keys |= set([name + DIVIDER + p for p in m.performance_metric_keys])
-        
+
+        for (name, fcn) in kwargs['functions']:
+            self.inputs |= set([name + DIVIDER + u for u in signature(fcn).parameters.keys()])
+            self.states.add(name + DIVIDER + 'return')
+
         # Handle outputs
         if 'outputs' in kwargs:
             if isinstance(kwargs['outputs'], str):
@@ -92,44 +112,61 @@ class CompositeModel(PrognosticsModel):
             if not isinstance(kwargs['outputs'], Iterable):
                 raise ValueError('The outputs argument must be a list[str]')
             if not set(kwargs['outputs']).issubset(self.outputs):
-                raise ValueError('The outputs of the composite model must be a subset of the outputs of the models')
+                raise ValueError(
+                    'The outputs of the composite model must be a '
+                    'subset of the outputs of the models')
             self.outputs = kwargs['outputs']
-        
+
         # Handle Connections
         kwargs['connections'] = []
-        self.__to_input_connections = {m_name: [] for m_name in self.model_names}
-        self.__to_state_connections = {m_name: [] for m_name in self.model_names}
-        self.__to_state_from_pm_connections = {m_name: [] for m_name in self.model_names}
+        self.__to_input_connections = {
+            m_name: [] for m_name in self.model_names}
+        self.__to_state_connections = {
+            m_name: [] for m_name in self.model_names}
+        self.__to_state_from_pm_connections = {
+            m_name: [] for m_name in self.model_names}
 
         for connection in connections:
             # Input validation
             if not isinstance(connection, Iterable) or len(connection) != 2:
-                raise ValueError('Each connection must be a tuple of the form (input: str, output: str)')
+                raise ValueError(
+                    'Each connection must be a tuple of the form'
+                    ' (input: str, output: str)')
             if not isinstance(connection[0], str) or not isinstance(connection[1], str):
-                raise ValueError('Each connection must be a tuple of the form (input: str, output: str)')
+                raise ValueError(
+                    'Each connection must be a tuple of the form'
+                    ' (input: str, output: str)')
 
             in_key, out_key = connection
             # Validation
             if out_key not in self.inputs:
-                raise ValueError(f'The output key, {out_key}, must be an input to one of the composite models. Options include {self.inputs}')
+                raise ValueError(
+                    f'The output key, {out_key}, must be an input'
+                    ' to one of the composite models. Options '
+                    f'include {self.inputs}')
 
             # Remove the out_key from inputs
             # These no longer are an input to the composite model
             # as they are now satisfied internally
             self.inputs.remove(out_key)
-                
+
             # Split the keys into parts (model, key_part)
             (in_model, in_key_part) = in_key.split('.')
             (out_model, out_key_part) = out_key.split('.')
 
             # Validate parts
             if in_model == out_model:
-                raise ValueError('The input and output models must be different')
+                raise ValueError(
+                    'The input and output models must be different')
             if in_model not in self.model_names:
-                raise ValueError('The input model must be one of the models in the composite model')
+                raise ValueError(
+                    'The input model must be one of the models'
+                    ' in the composite model')
             if out_model not in self.model_names:
-                raise ValueError('The output model must be one of the models in the composite model')
-            
+                raise ValueError(
+                    'The output model must be one of the models'
+                    ' in the composite model')
+
             # Add to connections
             if in_key in self.states:
                 self.__to_input_connections[out_model].append((in_key, out_key_part))
@@ -148,18 +185,20 @@ class CompositeModel(PrognosticsModel):
                 self.__to_state_from_pm_connections[out_model].append((in_key_part, in_key))
                 self.states.add(in_key)
             else:
-                raise ValueError('The input key must be an output or state of one of the composite models')
-        
+                raise ValueError(
+                    f'The input key {in_key} must be an output or state')
+
         # Finish initialization
         super().__init__(**kwargs)
 
-    def initialize(self, u={}, z={}):
+    def initialize(self, u=None, z=None):
         if u is None:
             u = {}
         if z is None:
             z = {}
 
         x_0 = {}
+
         # Initialize the models
         for (name, m) in self.parameters['models']:
             u_i = {key: u.get(name + '.' + key, None) for key in m.inputs}
@@ -169,7 +208,7 @@ class CompositeModel(PrognosticsModel):
                 x_0[name + '.' + key] = value
         
             # Process connections
-            # This initializes the states that are connected to outputs
+            # This initializes the states connected to outputs
             for (in_key_part, in_key) in self.__to_state_connections[name]:
                 if in_key in z.keys():
                     x_0[in_key] = z[in_key]
@@ -177,11 +216,22 @@ class CompositeModel(PrognosticsModel):
                     z_ii = m.output(x_i)
                     x_0[in_key] = z_ii.get(in_key_part, None)
 
-            # This initializes the states that are connected to performance metrics
+            # This initializes the states connected to performance metrics
             for (in_key_part, in_key) in self.__to_state_from_pm_connections[name]:
                 pm = m.performance_metrics(x_i)
                 x_0[in_key] = pm.get(in_key_part, None)
-                
+
+        # Initialize functions
+        for (name, fcn) in self.parameters['functions']:
+            keys = set(signature(fcn).parameters.keys())
+            fcn_in = {
+                fcn_key: x_0.get(out_key, z.get(out_key, None))
+                for (out_key, fcn_key) in self.__to_input_connections[name]}
+            for key in (keys - set(fcn_in.keys())):
+                # For remaining keys - get from input
+                fcn_in[key] = u.get(name + DIVIDER + key, None)
+            x_0[name + DIVIDER + 'return'] = fcn(**fcn_in)
+
         return self.StateContainer(x_0)
 
     def next_state(self, x, u, dt):
@@ -199,25 +249,36 @@ class CompositeModel(PrognosticsModel):
             x_i = m.StateContainer({key: x[name + '.' + key] for key in m.states})
 
             # Propagate state
-            x_next_i = m.next_state(x_i, u_i, dt)
+            x_i = m.next_state(x_i, u_i, dt)
 
             # Save to super state
-            for key, value in x_next_i.items():
+            for key, value in x_i.items():
                 x[name + '.' + key] = value
             
             # Process connections
             # This updates the states that are connected to outputs
             if len(self.__to_state_connections[name]) > 0:
                 # From Outputs
-                z_i = m.output(x_next_i)
+                z_i = m.output(x_i)
                 for (in_key_part, in_key) in self.__to_state_connections[name]:
                     x[in_key] = z_i.get(in_key_part, None)
 
             if len(self.__to_state_from_pm_connections) > 0:
                 # From Performance Metrics
-                pm_i = m.performance_metrics(x_next_i)
+                pm_i = m.performance_metrics(x_i)
                 for (in_key_part, in_key) in self.__to_state_from_pm_connections[name]:
                     x[in_key] = pm_i.get(in_key_part, None)
+
+        # Process functions
+        for (name, fcn) in self.parameters['functions']:
+            keys = set(signature(fcn).parameters.keys())
+            fcn_in = {
+                fcn_key: x.get(out_key, None)
+                for (out_key, fcn_key) in self.__to_input_connections[name]}
+            for key in (keys - set(fcn_in.keys())):
+                # For remaining keys - get from input
+                fcn_in[key] = u.get(name + DIVIDER + key, None)
+            x[name + DIVIDER + 'return'] = fcn(**fcn_in)
 
         return x
 
@@ -235,7 +296,7 @@ class CompositeModel(PrognosticsModel):
                 z[name + '.' + key] = value
         return self.OutputContainer(z)
 
-    def performance_metrics(self, x):
+    def performance_metrics(self, x) -> dict:
         metrics = {}
         for (name, m) in self.parameters['models']:
             # Prepare state
@@ -249,7 +310,7 @@ class CompositeModel(PrognosticsModel):
                 metrics[name + '.' + key] = value
         return metrics
 
-    def event_state(self, x):
+    def event_state(self, x) -> dict:
         e = {}
         for (name, m) in self.parameters['models']:
             # Prepare state
@@ -263,7 +324,7 @@ class CompositeModel(PrognosticsModel):
                 e[name + '.' + key] = value
         return e
 
-    def threshold_met(self, x):
+    def threshold_met(self, x) -> dict:
         tm = {}
         for (name, m) in self.parameters['models']:
             # Prepare state

--- a/tests/test_composite.py
+++ b/tests/test_composite.py
@@ -71,6 +71,184 @@ class TestCompositeModel(unittest.TestCase):
             # extra
             CompositeModel([m1, m1], outputs=['OneInputOneOutputNoEventLM.z1', 'OneInputOneOutputNoEventLM_2.z1', 'z1'])
 
+    def test_composite_function(self):
+        m1 = OneInputOneOutputNoEventLM()
+        m2 = OneInputNoOutputOneEventLM()
+        m1_withpm = OneInputOneOutputNoEventLMPM()
+
+        def fcn(u0, u1):
+            return u0+u1
+
+        # Test with no connections
+        m_composite = CompositeModel([m1, m1, fcn])
+        self.assertSetEqual(m_composite.states, {'OneInputOneOutputNoEventLM_2.x1', 'OneInputOneOutputNoEventLM.x1', 'function.return'})
+        self.assertSetEqual(m_composite.inputs, {'OneInputOneOutputNoEventLM.u1', 'OneInputOneOutputNoEventLM_2.u1', 'function.u0', 'function.u1'})
+        self.assertSetEqual(m_composite.outputs, {'OneInputOneOutputNoEventLM.z1', 'OneInputOneOutputNoEventLM_2.z1'})
+        self.assertSetEqual(m_composite.events, set())
+        self.assertSetEqual(m_composite.performance_metric_keys, set(), "Shouldn't have any performance metrics")
+
+        with self.assertRaises(TypeError):
+            # Missing connection to fill input of function
+            m_composite.initialize()
+
+        # But it should work if you provide inputs manually
+        x0 = m_composite.initialize({'function.u0': 2, 'function.u1': 8})
+        self.assertSetEqual(
+            set(x0.keys()),
+            {'OneInputOneOutputNoEventLM_2.x1', 'OneInputOneOutputNoEventLM.x1', 'function.return'})
+        self.assertEqual(x0['OneInputOneOutputNoEventLM_2.x1'], 0)
+        self.assertEqual(x0['OneInputOneOutputNoEventLM.x1'], 0)
+        self.assertEqual(x0['function.return'], 10)
+        # Only provide non-zero input for the first model
+        u = m_composite.InputContainer({'OneInputOneOutputNoEventLM.u1': 1, 'OneInputOneOutputNoEventLM_2.u1': 0, 'function.u0': 3, 'function.u1': 8})
+        x = m_composite.next_state(x0, u, 1)
+        self.assertSetEqual(
+            set(x.keys()),
+            {'OneInputOneOutputNoEventLM_2.x1', 'OneInputOneOutputNoEventLM.x1', 'function.return'})
+        self.assertEqual(x['OneInputOneOutputNoEventLM_2.x1'], 0)
+        self.assertEqual(x['OneInputOneOutputNoEventLM.x1'], 1)
+        self.assertEqual(x['function.return'], 11)
+
+        # Test with connections - 1/2 input to fcn only (only u0, not u1)
+        m_composite = CompositeModel(
+            [m1, m1, fcn],
+            connections=[
+                ('OneInputOneOutputNoEventLM.z1', 'OneInputOneOutputNoEventLM_2.u1'),
+                ('OneInputOneOutputNoEventLM.z1', 'function.u0')])
+        # Additional state to store output
+        self.assertSetEqual(m_composite.states, {'OneInputOneOutputNoEventLM_2.x1', 'OneInputOneOutputNoEventLM.x1', 'OneInputOneOutputNoEventLM.z1', 'function.return'})
+        # One less input - since it's internally connected
+        self.assertSetEqual(m_composite.inputs, {'OneInputOneOutputNoEventLM.u1', 'function.u1'})
+        self.assertSetEqual(m_composite.outputs, {'OneInputOneOutputNoEventLM.z1', 'OneInputOneOutputNoEventLM_2.z1'})
+        self.assertSetEqual(m_composite.events, set())
+
+        with self.assertRaises(TypeError):
+            # Missing connection to u1 to fill input of function
+            x0 = m_composite.initialize()
+        x0 = m_composite.initialize({'function.u1': 7})
+        self.assertSetEqual(
+            set(x0.keys()),
+            {'OneInputOneOutputNoEventLM_2.x1', 'OneInputOneOutputNoEventLM.x1', 'OneInputOneOutputNoEventLM.z1', 'function.return'})
+        self.assertEqual(x0['OneInputOneOutputNoEventLM_2.x1'], 0)
+        self.assertEqual(x0['OneInputOneOutputNoEventLM.x1'], 0)
+        self.assertEqual(x0['OneInputOneOutputNoEventLM.z1'], 0)
+        self.assertEqual(x0['function.return'], 7)
+        # Only provide non-zero input for first model
+        u = m_composite.InputContainer(
+            {'OneInputOneOutputNoEventLM.u1': 1, 'function.u1': 7})
+        x = m_composite.next_state(x0, u, 1)
+        self.assertSetEqual(
+            set(x.keys()),
+            {'OneInputOneOutputNoEventLM_2.x1', 'OneInputOneOutputNoEventLM.x1', 'OneInputOneOutputNoEventLM.z1', 'function.return'})
+        self.assertEqual(x['OneInputOneOutputNoEventLM_2.x1'], 1)
+        # Propagates through, because of the order.
+        # If the connection were the other way it wouldn't
+        self.assertEqual(x['OneInputOneOutputNoEventLM.x1'], 1)
+        self.assertEqual(x['function.return'], 8)
+
+        # Propagate again
+        x = m_composite.next_state(x, u, 1)
+        self.assertSetEqual(
+            set(x.keys()),
+            {'OneInputOneOutputNoEventLM_2.x1', 'OneInputOneOutputNoEventLM.x1', 'OneInputOneOutputNoEventLM.z1', 'function.return'})
+        self.assertEqual(x['OneInputOneOutputNoEventLM_2.x1'], 3)  # 1 + 2
+        self.assertEqual(x['OneInputOneOutputNoEventLM.x1'], 2)
+        self.assertEqual(x['function.return'], 9)
+
+        # Test with full connections in
+        m_composite = CompositeModel(
+            [m1, m1, fcn],
+            connections=[
+                ('OneInputOneOutputNoEventLM.z1', 'OneInputOneOutputNoEventLM_2.u1'),
+                ('OneInputOneOutputNoEventLM.z1', 'function.u0'),
+                ('OneInputOneOutputNoEventLM.z1', 'function.u1')])
+        # Additional state to store output
+        self.assertSetEqual(m_composite.states, {'OneInputOneOutputNoEventLM_2.x1', 'OneInputOneOutputNoEventLM.x1', 'OneInputOneOutputNoEventLM.z1', 'function.return'})
+        # One less input - since it's internally connected
+        self.assertSetEqual(m_composite.inputs, {'OneInputOneOutputNoEventLM.u1'})
+        self.assertSetEqual(m_composite.outputs, {'OneInputOneOutputNoEventLM.z1', 'OneInputOneOutputNoEventLM_2.z1'})
+        self.assertSetEqual(m_composite.events, set())
+
+        # Empty initialization should work now
+        x0 = m_composite.initialize()
+        self.assertSetEqual(
+            set(x0.keys()),
+            {'OneInputOneOutputNoEventLM_2.x1', 'OneInputOneOutputNoEventLM.x1', 'OneInputOneOutputNoEventLM.z1', 'function.return'})
+        self.assertEqual(x0['OneInputOneOutputNoEventLM_2.x1'], 0)
+        self.assertEqual(x0['OneInputOneOutputNoEventLM.x1'], 0)
+        self.assertEqual(x0['OneInputOneOutputNoEventLM.z1'], 0)
+        self.assertEqual(x0['function.return'], 0)
+        # Only provide non-zero input for first model
+        u = m_composite.InputContainer(
+            {'OneInputOneOutputNoEventLM.u1': 1})
+        x = m_composite.next_state(x0, u, 1)
+        self.assertSetEqual(
+            set(x.keys()),
+            {'OneInputOneOutputNoEventLM_2.x1', 'OneInputOneOutputNoEventLM.x1', 'OneInputOneOutputNoEventLM.z1', 'function.return'})
+        self.assertEqual(x['OneInputOneOutputNoEventLM_2.x1'], 1)
+        # Propagates through, because of the order.
+        # If the connection were the other way it wouldn't
+        self.assertEqual(x['OneInputOneOutputNoEventLM.x1'], 1)
+        self.assertEqual(x['function.return'], 2)
+
+        # Propagate again
+        x = m_composite.next_state(x, u, 1)
+        self.assertSetEqual(
+            set(x.keys()),
+            {'OneInputOneOutputNoEventLM_2.x1', 'OneInputOneOutputNoEventLM.x1', 'OneInputOneOutputNoEventLM.z1', 'function.return'})
+        self.assertEqual(x['OneInputOneOutputNoEventLM_2.x1'], 3)  # 1 + 2
+        self.assertEqual(x['OneInputOneOutputNoEventLM.x1'], 2)
+        self.assertEqual(x['function.return'], 4)
+
+        # Test with full connections in and out
+        # Update function to add one each timestep
+        def fcn(u0, u1) -> float:
+            return u0 + u1 + 1
+        m_composite = CompositeModel(
+            [m1, m1, fcn],
+            connections=[
+                ('OneInputOneOutputNoEventLM.z1', 'OneInputOneOutputNoEventLM_2.u1'),
+                ('OneInputOneOutputNoEventLM.z1', 'function.u0'),
+                ('OneInputOneOutputNoEventLM.z1', 'function.u1'),
+                ('function.return', 'OneInputOneOutputNoEventLM.u1')])
+        # Additional state to store output
+        self.assertSetEqual(m_composite.states, {'OneInputOneOutputNoEventLM_2.x1', 'OneInputOneOutputNoEventLM.x1', 'OneInputOneOutputNoEventLM.z1', 'function.return'})
+        # Two less input - since it's fully internally connected
+        self.assertSetEqual(m_composite.inputs, set())
+        self.assertSetEqual(m_composite.outputs, {'OneInputOneOutputNoEventLM.z1', 'OneInputOneOutputNoEventLM_2.z1'})
+        self.assertSetEqual(m_composite.events, set())
+
+        # Empty initialization should work
+        x0 = m_composite.initialize()
+        self.assertSetEqual(
+            set(x0.keys()),
+            {'OneInputOneOutputNoEventLM_2.x1', 'OneInputOneOutputNoEventLM.x1', 'OneInputOneOutputNoEventLM.z1', 'function.return'})
+        self.assertEqual(x0['OneInputOneOutputNoEventLM_2.x1'], 0)
+        self.assertEqual(x0['OneInputOneOutputNoEventLM.x1'], 0)
+        self.assertEqual(x0['OneInputOneOutputNoEventLM.z1'], 0)
+        self.assertEqual(x0['function.return'], 1)
+        # Only provide non-zero input for first model
+        u = m_composite.InputContainer(
+            {})
+        x = m_composite.next_state(x0, u, 1)
+        self.assertSetEqual(
+            set(x.keys()),
+            {'OneInputOneOutputNoEventLM_2.x1', 'OneInputOneOutputNoEventLM.x1', 'OneInputOneOutputNoEventLM.z1', 'function.return'})
+        self.assertEqual(x['OneInputOneOutputNoEventLM_2.x1'], 1)
+        # Propagates through, because of the order.
+        # If the connection were the other way it wouldn't
+        self.assertEqual(x['OneInputOneOutputNoEventLM.x1'], 1)
+        self.assertEqual(x['function.return'], 3)  # 1 + 1 + 1
+
+        # Propagate again
+        x = m_composite.next_state(x, u, 1)
+        self.assertSetEqual(
+            set(x.keys()),
+            {'OneInputOneOutputNoEventLM_2.x1', 'OneInputOneOutputNoEventLM.x1', 'OneInputOneOutputNoEventLM.z1', 'function.return'})
+        self.assertEqual(x['OneInputOneOutputNoEventLM_2.x1'], 5)  # 1 + 2
+        self.assertEqual(x['OneInputOneOutputNoEventLM.x1'], 4)
+        self.assertEqual(x['function.return'], 9)  # 4 + 4 + 1
+
     def test_composite(self):
         m1 = OneInputOneOutputNoEventLM()
         m2 = OneInputNoOutputOneEventLM()


### PR DESCRIPTION
Updated composite model to allow generic functions of one or more argument f(...)->float to be used for simple transformations between models.

Function inputs are the argument names. Outputs is 'function.return'.

Also added tests, updated the description, and added to the combining models example notebook.

Also a few changes cleaning up the code (applying linter suggestions) in composite model