### PR TITLE
Fix noise transfer

### DIFF
--- a/src/progpy/models/test_models/linear_models.py
+++ b/src/progpy/models/test_models/linear_models.py
@@ -43,6 +43,26 @@ class OneInputNoOutputNoEventLM(LinearModel):
         }
     }
 
+class OneInputTwoStatesNoOutputNoEventLM(LinearModel):
+    """
+    Simple model that increases state by u1 every step. 
+    """
+    inputs = ['u1']
+    states = ['x1', 'x2']
+
+    A = np.array([[0, 0], [0, 0]])
+    B = np.array([[1], [0]])
+    C = np.empty((0,2))
+    F = np.empty((0,2))
+
+    default_parameters = {
+        'process_noise': 0,
+        'x0': {
+            'x1': 0,
+            'x2': 0
+        }
+    }
+
 
 class OneInputOneOutputNoEventLM(LinearModel):
     """

--- a/tests/test_base_models.py
+++ b/tests/test_base_models.py
@@ -13,7 +13,7 @@ sys.path.append(join(dirname(__file__), ".."))
 
 from progpy import PrognosticsModel, CompositeModel
 from progpy.models import ThrownObject, BatteryElectroChemEOD
-from progpy.models.test_models.linear_models import (OneInputNoOutputNoEventLM, OneInputOneOutputNoEventLM, OneInputNoOutputOneEventLM, OneInputOneOutputNoEventLMPM)
+from progpy.models.test_models.linear_models import (OneInputNoOutputNoEventLM, OneInputOneOutputNoEventLM, OneInputTwoStatesNoOutputNoEventLM, OneInputNoOutputOneEventLM, OneInputOneOutputNoEventLMPM)
 from progpy.models.test_models.linear_thrown_object import (LinearThrownObject, LinearThrownDiffThrowingSpeed, LinearThrownObjectUpdatedInitializedMethod, LinearThrownObjectDiffDefaultParams)
 
 
@@ -159,6 +159,14 @@ class TestModels(unittest.TestCase):
         # This is because we changed the integration method to rk4 for the default model
         self.assertEqual(x_default['v'], x_rk4['v'])
         self.assertEqual(x_default['x'], x_rk4['x'])
+
+    def test_parameters_statelikematrixwrapper(self):
+        """
+        This is testing a very specific case where a state container from one model is used to define the noise from another.
+        """
+        m0 = OneInputTwoStatesNoOutputNoEventLM()
+        m1 = OneInputNoOutputNoEventLM(process_noise=m0.parameters['process_noise'])
+        self.assertSetEqual(set(m1.parameters['process_noise'].keys()), set(m1.states))
 
     def test_integration_type_scipy(self):
         # SciPy Integrator test.

--- a/tests/test_base_models.py
+++ b/tests/test_base_models.py
@@ -164,8 +164,8 @@ class TestModels(unittest.TestCase):
         """
         This is testing a very specific case where a state container from one model is used to define the noise from another.
         """
-        m0 = OneInputTwoStatesNoOutputNoEventLM()
-        m1 = OneInputNoOutputNoEventLM(process_noise=m0.parameters['process_noise'])
+        m0 = OneInputNoOutputNoEventLM()
+        m1 = OneInputTwoStatesNoOutputNoEventLM(process_noise=m0.parameters['process_noise'])
         self.assertSetEqual(set(m1.parameters['process_noise'].keys()), set(m1.states))
 
     def test_integration_type_scipy(self):


### PR DESCRIPTION
Fixes a bug where when noise is transferred from one model to another (i.e., the noise from one model is used to set the other), the missing keys in *_noise are not set, because the object is already a DictLikeMatrix wrapper. 

This becomes an issue with models with dynamic states and events. The first of these models is being tested in the SWS project