### PR TITLE
Refactor to include u in the output field

### DIFF
--- a/docs/_downloads/05795c561b0fb31137ef5fd753641074/new_state_estimator_example.py
+++ b/docs/_downloads/05795c561b0fb31137ef5fd753641074/new_state_estimator_example.py
@@ -43,8 +43,8 @@ class BlindlyStumbleEstimator(StateEstimator):
         x2 = {key : float(value) + 10*(random.random()-0.5) for (key,value) in self.state.items()}
 
         # Calculate outputs
-        z_est = self.m.output(t, self.state)
-        z_est2 = self.m.output(t, x2)
+        z_est = self.m.output(t)
+        z_est2 = self.m.output(t)
 
         # Now score them each by how close they are to the measured z
         z_est_score = sum([abs(z_est[key] - z[key]) for key in self.m.outputs])

--- a/docs/_downloads/06717c7dc69742382bea70d35e4e63b5/sim_pump.py
+++ b/docs/_downloads/06717c7dc69742382bea70d35e4e63b5/sim_pump.py
@@ -34,7 +34,7 @@ def run_example():
         })
 
     # Step 3: Sim
-    first_output = pump.output(pump.initialize(future_loading(0),{}))
+    first_output = pump.output(pump.initialize(future_loading(0), {}))
     config = {
         'horizon': 1e5,
         'save_freq': 1e3,

--- a/docs/_downloads/07c9eb121dbb5de8d48ddffc704c521d/new_state_estimator_example.py
+++ b/docs/_downloads/07c9eb121dbb5de8d48ddffc704c521d/new_state_estimator_example.py
@@ -43,8 +43,8 @@ class BlindlyStumbleEstimator(StateEstimator):
         x2 = {key : float(value) + 10*(random.random()-0.5) for (key,value) in self.state.items()}
 
         # Calculate outputs
-        z_est = self.m.output(t, self.state)
-        z_est2 = self.m.output(t, x2)
+        z_est = self.m.output(t)
+        z_est2 = self.m.output(t)
 
         # Now score them each by how close they are to the measured z
         z_est_score = sum([abs(z_est[key] - z[key]) for key in self.m.outputs])

--- a/docs/_downloads/0f7c5af7c0ba09c1be3bd3db3e6458c9/prog_model_template.py
+++ b/docs/_downloads/0f7c5af7c0ba09c1be3bd3db3e6458c9/prog_model_template.py
@@ -223,7 +223,7 @@ class ProgModelTemplate(PrognosticsModel):
     #
     #     return self.StateContainer(next_x)
 
-    def output(self, x):
+    def output(self, x, u=None):
         """
         Calculate output, z (i.e., measurable values) given the state x
 
@@ -238,6 +238,7 @@ class ProgModelTemplate(PrognosticsModel):
         z : OutputContainer
             Outputs, with keys defined by model.outputs.
             e.g., z = {'t':12.4, 'v':3.3} given inputs = ['t', 'v']
+            :param u:
         """
 
         # REPLACE BELOW WITH LOGIC TO CALCULATE OUTPUTS

--- a/docs/_downloads/7c5976947f77971a5ed9939937b15116/measurement_eqn_example.py
+++ b/docs/_downloads/7c5976947f77971a5ed9939937b15116/measurement_eqn_example.py
@@ -88,7 +88,7 @@ def run_example():
     class MyBattery(Battery):
         outputs = ['tv']  # output is temperature * voltage (for some reason)
 
-        def output(self, x):
+        def output(self, x, u=None):
             parent.parameters = self.parameters  # only needed if you expect to change parameters
             z = parent.output(x)
             return self.OutputContainer({'tv': z['v'] * z['t']})

--- a/docs/_downloads/b997c950df7e2f695c19319712091ba3/measurement_eqn_example.py
+++ b/docs/_downloads/b997c950df7e2f695c19319712091ba3/measurement_eqn_example.py
@@ -88,7 +88,7 @@ def run_example():
     class MyBattery(Battery):
         outputs = ['tv']  # output is temperature * voltage (for some reason)
 
-        def output(self, x):
+        def output(self, x, u=None):
             parent.parameters = self.parameters  # only needed if you expect to change parameters
             z = parent.output(x)
             return self.OutputContainer({'tv': z['v'] * z['t']})

--- a/docs/_downloads/c416c00aa2e02950fa0b0b4547cf49f9/new_model.py
+++ b/docs/_downloads/c416c00aa2e02950fa0b0b4547cf49f9/new_model.py
@@ -46,7 +46,7 @@ class ThrownObject(PrognosticsModel):
         return self.StateContainer({'x': x['v'],
                 'v': self.parameters['g']})  # Acceleration of gravity
 
-    def output(self, x):
+    def output(self, x, u=None):
         return self.OutputContainer({'x': x['x']})
 
     # This is actually optional. Leaving thresholds_met empty will use the event state to define thresholds.

--- a/docs/_downloads/daafe64ff08a2ab2ed2ab052cf9985bf/sim_pump.py
+++ b/docs/_downloads/daafe64ff08a2ab2ed2ab052cf9985bf/sim_pump.py
@@ -35,7 +35,7 @@ def run_example():
         })
 
     # Step 3: Sim
-    first_output = pump.output(pump.initialize(future_loading(0),{}))
+    first_output = pump.output(pump.initialize(future_loading(0), {}))
     config = {
         'horizon': 1e5,
         'save_freq': 1e3,

--- a/docs/_downloads/e2fe425b405c324c9ddabb88b4675b84/sim_pump.py
+++ b/docs/_downloads/e2fe425b405c324c9ddabb88b4675b84/sim_pump.py
@@ -35,7 +35,7 @@ def run_example():
         })
 
     # Step 3: Sim
-    first_output = pump.output(pump.initialize(future_loading(0),{}))
+    first_output = pump.output(pump.initialize(future_loading(0), {}))
     config = {
         'horizon': 1e5,
         'save_freq': 1e3,

--- a/examples/measurement_eqn_example.py
+++ b/examples/measurement_eqn_example.py
@@ -88,7 +88,7 @@ def run_example():
     class MyBattery(Battery):
         outputs = ['tv']  # output is temperature * voltage (for some reason)
 
-        def output(self, x):
+        def output(self, x, u=None):
             parent.parameters = self.parameters  # only needed if you expect to change parameters
             z = parent.output(x)
             return self.OutputContainer({'tv': z['v'] * z['t']})

--- a/examples/new_model.py
+++ b/examples/new_model.py
@@ -46,7 +46,7 @@ class ThrownObject(PrognosticsModel):
         return self.StateContainer({'x': x['v'],
                 'v': self.parameters['g']})  # Acceleration of gravity
 
-    def output(self, x):
+    def output(self, x, u=None):
         return self.OutputContainer({'x': x['x']})
 
     # This is actually optional. Leaving thresholds_met empty will use the event state to define thresholds.

--- a/examples/new_state_estimator_example.py
+++ b/examples/new_state_estimator_example.py
@@ -43,8 +43,8 @@ class BlindlyStumbleEstimator(StateEstimator):
         x2 = {key : float(value) + 10*(random.random()-0.5) for (key,value) in self.state.items()}
 
         # Calculate outputs
-        z_est = self.m.output(t, self.state)
-        z_est2 = self.m.output(t, x2)
+        z_est = self.m.output(t)
+        z_est2 = self.m.output(t)
 
         # Now score them each by how close they are to the measured z
         z_est_score = sum([abs(z_est[key] - z[key]) for key in self.m.outputs])

--- a/examples/sim_pump.py
+++ b/examples/sim_pump.py
@@ -35,7 +35,7 @@ def run_example():
         })
 
     # Step 3: Sim
-    first_output = pump.output(pump.initialize(future_loading(0),{}))
+    first_output = pump.output(pump.initialize(future_loading(0), {}))
     config = {
         'horizon': 1e5,
         'save_freq': 1e3,

--- a/prog_model_template.py
+++ b/prog_model_template.py
@@ -223,7 +223,7 @@ class ProgModelTemplate(PrognosticsModel):
     #
     #     return self.StateContainer(next_x)
 
-    def output(self, x):
+    def output(self, x, u=None):
         """
         Calculate output, z (i.e., measurable values) given the state x
 
@@ -238,6 +238,7 @@ class ProgModelTemplate(PrognosticsModel):
         z : OutputContainer
             Outputs, with keys defined by model.outputs.
             e.g., z = {'t':12.4, 'v':3.3} given inputs = ['t', 'v']
+            :param u:
         """
 
         # REPLACE BELOW WITH LOGIC TO CALCULATE OUTPUTS

--- a/sphinx-config/auto_examples/sim_pump.py
+++ b/sphinx-config/auto_examples/sim_pump.py
@@ -34,7 +34,7 @@ def run_example():
         })
 
     # Step 3: Sim
-    first_output = pump.output(pump.initialize(future_loading(0),{}))
+    first_output = pump.output(pump.initialize(future_loading(0), {}))
     config = {
         'horizon': 1e5,
         'save_freq': 1e3,

--- a/src/progpy/composite_model.py
+++ b/src/progpy/composite_model.py
@@ -221,7 +221,7 @@ class CompositeModel(PrognosticsModel):
 
         return x
 
-    def output(self, x):
+    def output(self, x, u=None):
         z = {}
         for (name, m) in self.parameters['models']:
             # Prepare state

--- a/src/progpy/data_models/lstm_model.py
+++ b/src/progpy/data_models/lstm_model.py
@@ -142,7 +142,7 @@ class LSTMStateTransitionModel(DataModel):
         result = np.array(np.vstack((states, internal_states)), dtype=np.float64)
         return self.StateContainer(result)
 
-    def output(self, x):
+    def output(self, x, u=None):
         if x.matrix[0, 0] is None:
             warn(f"Output estimation is not available until at least {1+self.parameters['window']} timesteps have passed.")
             return self.OutputContainer(np.array([[None] for _ in self.outputs]))

--- a/src/progpy/ensemble_model.py
+++ b/src/progpy/ensemble_model.py
@@ -89,7 +89,7 @@ class EnsembleModel(PrognosticsModel):
 
         return self.StateContainer(xs_final)
         
-    def output(self, x):
+    def output(self, x, u=None):
         zs = [m.output(m.StateContainer(x)) for m in self.parameters['models']]
         zs_final = {}
         for z in zs:

--- a/src/progpy/linear_model.py
+++ b/src/progpy/linear_model.py
@@ -222,7 +222,7 @@ class LinearModel(PrognosticsModel, ABC):
             dx_array += np.matmul(self.B, u.matrix)
         return self.StateContainer(dx_array)
 
-    def output(self, x):
+    def output(self, x, u=None):
         z_array = np.matmul(self.C, x.matrix) + self.D
         return self.OutputContainer(z_array)
 

--- a/src/progpy/mixture_of_experts.py
+++ b/src/progpy/mixture_of_experts.py
@@ -187,7 +187,7 @@ class MixtureOfExpertsModel(CompositeModel):
                 best_index = i
         return self.parameters['models'][best_index]
 
-    def output(self, x):
+    def output(self, x, u=None):
         excepting = []
         outputs_seen = set()
         z = {}

--- a/src/progpy/models/aircraft_model/small_rotorcraft.py
+++ b/src/progpy/models/aircraft_model/small_rotorcraft.py
@@ -242,7 +242,7 @@ class SmallRotorcraft(AircraftModel):
         # Based on percentage of reference trajectory completed
         return {'TrajectoryComplete': x['mission_complete']}
  
-    def output(self, x):
+    def output(self, x, u=None):
         # Output is the same as the state vector, without time and mission_complete
         return self.OutputContainer(x.matrix[0:-2])
 

--- a/src/progpy/models/battery_circuit.py
+++ b/src/progpy/models/battery_circuit.py
@@ -185,7 +185,7 @@ class BatteryCircuit(PrognosticsModel):
             'EOD': np.minimum(charge_EOD, voltage_EOD)
         }
 
-    def output(self, x):
+    def output(self, x, u=None):
         parameters = self.parameters
         Vcs = x['qcs']/parameters['Cs']
         Vcp = x['qcp']/parameters['Ccp']

--- a/src/progpy/models/battery_electrochem.py
+++ b/src/progpy/models/battery_electrochem.py
@@ -476,7 +476,7 @@ class BatteryElectroChemEOD(PrognosticsModel):
             'EOD': np.clip(min(charge_EOD, voltage_EOD), 0, 1)
         }
 
-    def output(self, x):
+    def output(self, x, u=None):
         params = self.parameters
         An = params['An']
         # Negative Surface
@@ -628,7 +628,7 @@ class BatteryElectroChemEOL(PrognosticsModel):
     def threshold_met(self, x) -> dict:
         return {'InsufficientCapacity': x['qMax'] < self.parameters['qMaxThreshold']}
 
-    def output(self, _):
+    def output(self, x, u=None):
         return self.OutputContainer(np.array([]))
 
 def merge_dicts(a: dict, b: dict) -> None:
@@ -709,7 +709,7 @@ class BatteryElectroChemEODEOL(BatteryElectroChemEOL, BatteryElectroChemEOD):
         x_dot.matrix = np.vstack((x_dot.matrix, x_dot2.matrix))
         return x_dot
 
-    def output(self, x):
+    def output(self, x, u=None):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             self.parameters['qMobile'] = x['qMax']

--- a/src/progpy/models/centrifugal_pump.py
+++ b/src/progpy/models/centrifugal_pump.py
@@ -246,7 +246,7 @@ class CentrifugalPumpBase(PrognosticsModel):
 
         return self.StateContainer(state_array)
 
-    def output(self, x):
+    def output(self, x, u=None):
         Qout = np.maximum(0, x['Q']-x['QLeak'])
 
         return self.OutputContainer({

--- a/src/progpy/models/dcmotor.py
+++ b/src/progpy/models/dcmotor.py
@@ -196,5 +196,5 @@ class DCMotor(PrognosticsModel):
         x.matrix[4] %= PI2  # Wrap angle
         return x
 
-    def output(self, x):
+    def output(self, x, u=None):
         return self.OutputContainer(x.matrix[3:])

--- a/src/progpy/models/dcmotor_singlephase.py
+++ b/src/progpy/models/dcmotor_singlephase.py
@@ -165,7 +165,7 @@ class DCMotorSP(PrognosticsModel):
             np.atleast_1d(dvrotdt)          # rotor speed
         ]))
 
-    def output(self, x):
+    def output(self, x, u=None):
         rotor_speed = x['v_rot']
         return self.OutputContainer(np.array([
             np.atleast_1d(rotor_speed),

--- a/src/progpy/models/esc.py
+++ b/src/progpy/models/esc.py
@@ -108,5 +108,5 @@ class ESC(PrognosticsModel):
             np.atleast_1d(VP[2]),
             np.atleast_1d(x['t'] + dt)]))
 
-    def output(self, x):
+    def output(self, x, u=None):
         return self.OutputContainer(x)

--- a/src/progpy/models/experimental/paris_law.py
+++ b/src/progpy/models/experimental/paris_law.py
@@ -79,7 +79,7 @@ class ParisLawCrackGrowth(PrognosticsModel):
         dxdt = {'c_l': r}
         return self.StateContainer(dxdt)
 
-    def output(self, x):
+    def output(self, x, u=None):
         return self.OutputContainer(x)
 
     def event_state(self, x) -> dict:

--- a/src/progpy/models/pneumatic_valve.py
+++ b/src/progpy/models/pneumatic_valve.py
@@ -326,7 +326,7 @@ class PneumaticValveBase(PrognosticsModel):
             np.atleast_1d(dp)                                # pL - pR
         ]))
     
-    def output(self, x):
+    def output(self, x, u=None):
         params = self.parameters  # Optimization
         indicatorTopm = (x['x'] >= params['Ls']-params['indicatorTol'])
         indicatorBotm = (x['x'] <= params['indicatorTol'])

--- a/src/progpy/models/powertrain.py
+++ b/src/progpy/models/powertrain.py
@@ -140,7 +140,7 @@ class Powertrain(PrognosticsModel):
 
         return self.StateContainer(x_esc)
 
-    def output(self, x):
+    def output(self, x, u=None):
         return self.OutputContainer(
             {
                 'v_rot': x['v_rot'], 

--- a/src/progpy/models/propeller_load.py
+++ b/src/progpy/models/propeller_load.py
@@ -60,5 +60,5 @@ class PropellerLoad(PrognosticsModel):
         return self.StateContainer({
             't_l': self.parameters['C_q']*u['v_rot']**2})
     
-    def output(self, x):
+    def output(self, x, u=None):
         return x

--- a/src/progpy/models/test_models/other_models.py
+++ b/src/progpy/models/test_models/other_models.py
@@ -27,7 +27,7 @@ class OneInputTwoOutputsOneEvent(PrognosticsModel):
             'x0': self.parameters['a'] * u['u0']
         })
 
-    def output(self, x):
+    def output(self, x, u=None):
         return self.OutputContainer({
             'x0+b': x['x0'] + self.parameters['b'],
             'x0+c': x['x0'] + self.parameters['c']
@@ -64,7 +64,7 @@ class OneInputTwoOutputsOneEvent_alt(PrognosticsModel):
             'x0': self.parameters['a'] * u['u0']
         })
 
-    def output(self, x):
+    def output(self, x, u=None):
         return self.OutputContainer({
             'x0+d': x['x0'] + self.parameters['d'],
             'x0+c': x['x0'] + self.parameters['c']

--- a/src/progpy/models/thrown_object.py
+++ b/src/progpy/models/thrown_object.py
@@ -97,7 +97,7 @@ class ThrownObject(PrognosticsModel):
                 np.atleast_1d(next_v)  # Acceleration of gravity
             ]))
 
-    def output(self, x):
+    def output(self, x, u=None):
         return self.OutputContainer(np.array([[x['x']]]))
 
     def threshold_met(self, x) -> dict:

--- a/src/progpy/prognostics_model.py
+++ b/src/progpy/prognostics_model.py
@@ -462,7 +462,7 @@ class PrognosticsModel(ABC):
 
     observables = performance_metrics  # For backwards compatibility
 
-    def output(self, x):
+    def output(self, x, u=None):
         """
         Calculate :term:`output` given state
 
@@ -471,6 +471,9 @@ class PrognosticsModel(ABC):
         x : StateContainer
             state, with keys defined by model.states \n
             e.g., x = m.StateContainer({'abc': 332.1, 'def': 221.003}) given states = ['abc', 'def']
+        u : InputContainer
+            Inputs, with keys defined by model.inputs \n
+            e.g., u = m.InputContainer({'i':3.2}) given inputs = ['i']
 
         Returns
         -------

--- a/tests/test_base_models.py
+++ b/tests/test_base_models.py
@@ -350,7 +350,7 @@ class TestModels(unittest.TestCase):
                 pass
             def next_state(self, x, u, dt):
                 pass
-            def output(self, x):
+            def output(self, x, u=None):
                 pass
         
 
@@ -363,7 +363,7 @@ class TestModels(unittest.TestCase):
                 pass
             def next_state(self, x, u, dt):
                 pass
-            def output(self, x):
+            def output(self, x, u=None):
                 pass
         
 
@@ -375,7 +375,7 @@ class TestModels(unittest.TestCase):
                 pass
             def next_state(self, x, u, dt):
                 pass
-            def output(self, x):
+            def output(self, x, u=None):
                 pass
         
 
@@ -387,7 +387,7 @@ class TestModels(unittest.TestCase):
                 pass
             def next_state(self, x, u, dt):
                 pass
-            def output(self, x):
+            def output(self, x, u=None):
                 pass
         
 
@@ -398,7 +398,7 @@ class TestModels(unittest.TestCase):
             parameters = {'process_noise': 0.1}
             def next_state(self, x, u, dt):
                 pass
-            def output(self, x):
+            def output(self, x, u=None):
                 pass
         
 

--- a/tests/test_centrifugal_pump.py
+++ b/tests/test_centrifugal_pump.py
@@ -85,8 +85,7 @@ class TestCentrifugalPump(unittest.TestCase):
         # Wear rates are parameters instead of states
         pump.parameters['wA'] = 1e-2
         pump.parameters['wThrust'] = 1e-10
-        (times, inputs, states, outputs, event_states) = pump.simulate_to_threshold(future_loading, pump.output(
-            pump.initialize(future_loading(0), {})))
+        (times, inputs, states, outputs, event_states) = pump.simulate_to_threshold(future_loading, pump.output(pump.initialize(future_loading(0), {})))
         self.assertAlmostEqual(times[-1], 23892)
 
     def test_centrifugal_pump_with_wear(self):
@@ -162,8 +161,7 @@ class TestCentrifugalPump(unittest.TestCase):
 
         pump.parameters['x0']['wA'] = 1e-2
         pump.parameters['x0']['wThrust'] = 1e-10
-        (times, inputs, states, outputs, event_states) = pump.simulate_to_threshold(future_loading, pump.output(
-            pump.initialize(future_loading(0), {})))
+        (times, inputs, states, outputs, event_states) = pump.simulate_to_threshold(future_loading, pump.output(pump.initialize(future_loading(0), {})))
         self.assertAlmostEqual(times[-1], 23892)
 
         # Check warning when changing overwritten Parameters

--- a/tests/test_predictors.py
+++ b/tests/test_predictors.py
@@ -35,7 +35,7 @@ class MockProgModel(PrognosticsModel):
         x['t']+= dt
         return x
 
-    def output(self, x):
+    def output(self, x, u=None):
         return {'o1': x['a'] + x['b'] + x['c']}
     
     def event_state(self, x):

--- a/tests/test_state_estimators.py
+++ b/tests/test_state_estimators.py
@@ -47,7 +47,7 @@ class MockProgModel(PrognosticsModel):
         x['t']+= dt
         return x
 
-    def output(self, x):
+    def output(self, x, u=None):
         return {'o1': x['a'] + x['b'] + x['c']}
     
     def event_state(self, x):
@@ -63,7 +63,7 @@ class MockProgModel(PrognosticsModel):
 
 class MockProgModel2(MockProgModel):
     outputs = ['o1', 'o2']
-    def output(self, x):
+    def output(self, x, u=None):
         return self.OutputContainer({
             'o1': x['a'] + x['b'] + x['c'], 
             'o2': 7


### PR DESCRIPTION
Fixes #141 by introducing a "u" parameter to the signature. I made it `None` by default so that existing implementations of StateEstimator classes and PrognosticModels need not change.