### PR TITLE
[Closes #146] Simulation/Prediction Ending Strategy

### DIFF
--- a/examples/01_Simulation.ipynb
+++ b/examples/01_Simulation.ipynb
@@ -332,6 +332,49 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "In this example we specified events='impact' to indicate that simulation should stop when the specified event 'impact' is met. By default, the simulation will stop when the first of the specified events occur. If you dont specify any events, all model events will be included (in this case ['falling', 'impact']). This means that without specifying events, execution would have ended early, when the object starts falling, like below:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results = m.simulate_to_threshold(save_freq=0.5, dt=0.1)\n",
+    "print('Last timestep: ', results.times[-1])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that simulation stopped at around 3.8seconds, about when the object starts falling. \n",
+    "\n",
+    "Alternately, if we would like to execute until all events have occurred we can use the `event_strategy` argument, like below:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results = m.simulate_to_threshold(save_freq=0.5, dt=0.1, event_strategy='all')\n",
+    "print('Last timestep: ', results.times[-1])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Not the simulation stopped at around 7.9 seconds, when the last of the events occured ('impact')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "This is a basic example of simulating to an event. However, this is still just an example. Most models will have some form of input or loading. Simulating these models is described in the following section. The remainder of the sections go through various features for customizing simulation further."
    ]
   },

--- a/src/progpy/predictors/monte_carlo.py
+++ b/src/progpy/predictors/monte_carlo.py
@@ -113,7 +113,7 @@ class MonteCarlo(Predictor):
         if 'events' in params: 
             # Params is provided as a argument in construction
             # Remove it so it's not passed to simulate_to*
-            def params['events']
+            del params['events']
 
         # Sample from state if n_samples specified or state is not UnweightedSamples (Case 2)
         # Or if is Unweighted samples, but there are the wrong number of samples (Case 1)

--- a/src/progpy/predictors/monte_carlo.py
+++ b/src/progpy/predictors/monte_carlo.py
@@ -101,9 +101,19 @@ class MonteCarlo(Predictor):
         if events is None:
             # Predict to all events
             # change to list because of limits of jsonify
-            events = list(self.model.events)
+            if 'events' in params and params['events'] is not None:
+                # Set at a model level
+                events = list(params['events'])
+            else:
+                # Otherwise, all events
+                events = list(self.model.events)
         if len(events) == 0 and 'horizon' not in params:
             raise ValueError("If specifying no event (i.e., simulate to time), must specify horizon")
+
+        if 'events' in params: 
+            # Params is provided as a argument in construction
+            # Remove it so it's not passed to simulate_to*
+            def params['events']
 
         # Sample from state if n_samples specified or state is not UnweightedSamples (Case 2)
         # Or if is Unweighted samples, but there are the wrong number of samples (Case 1)

--- a/src/progpy/predictors/unscented_transform.py
+++ b/src/progpy/predictors/unscented_transform.py
@@ -89,6 +89,7 @@ class UnscentedTransformPredictor(Predictor):
         'kappa': -1,
         't0': 0,
         'dt': 0.5,
+        'event_strategy': 'all',
         'horizon': 1e99,
         'save_pts': [],
         'save_freq': 1e99
@@ -175,6 +176,9 @@ class UnscentedTransformPredictor(Predictor):
         params = deepcopy(self.parameters) # copy parameters
         params.update(kwargs) # update for specific run
 
+        if params['event_strategy'] != 'all':
+            raise ValueError(f"`event_strategy` {params['event_strategy']} not supported. Currently, only 'all' event strategy is supported")
+
         if events is None:
             # Predict to all events
             # change to list because of limits of jsonify
@@ -252,7 +256,7 @@ class UnscentedTransformPredictor(Predictor):
                         all_failed = False  # This event for this sigma point hasn't been met yet
             if all_failed:
                 # If all events have been reched for every sigma point
-                break 
+                break
         
         # Prepare Results
         pts = array([[e for e in ToE[key]] for key in ToE.keys()])

--- a/tests/test_base_models.py
+++ b/tests/test_base_models.py
@@ -604,6 +604,18 @@ class TestModels(unittest.TestCase):
         (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(load, {'o1': 0.8}, dt=0.5, save_freq=1.0, events=['e1', 'e2'])
         self.assertAlmostEqual(times[-1], 5.0, 5)
 
+        # Any event, manual - specified strategy
+        (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(load, {'o1': 0.8}, dt=0.5, save_freq=1.0, events=['e1', 'e2'], event_strategy='first')
+        self.assertAlmostEqual(times[-1], 5.0, 5)
+
+        # both e1, e2
+        (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(load, {'o1': 0.8}, dt=0.5, save_freq=1.0, events=['e1', 'e2'], event_strategy='all')
+        self.assertAlmostEqual(times[-1], 15.0, 5)
+
+        # Any event, manual - unexpected strategy
+        with self.assertRaises(ValueError):
+            (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(load, {'o1': 0.8}, dt=0.5, save_freq=1.0, events=['e1', 'e2'], event_strategy='fljsdk')
+
         # Only event 2
         (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(load, {'o1': 0.8}, dt=0.5, save_freq=1.0, events=['e2'])
         self.assertAlmostEqual(times[-1], 15.0, 5)


### PR DESCRIPTION
Add a method of specifying a "strategy" for ending simulation and prediction. This is called the "event_strategy", and can be one of the following:
'first': Stop when the first event of the list is met
'all': Stop when all events in the list are met

Also added tests and added to tutorial.

Note: UTP is setup to only support 'all'. If you specify anything else, it will return an error. #150  opened to eventually add this functionality
