### PR TITLE
Fix tests_tolerance

### DIFF
--- a/tests/test_estimate_params.py
+++ b/tests/test_estimate_params.py
@@ -957,11 +957,11 @@ class TestEstimateParams(unittest.TestCase):
             m.estimate_params(times = results.times, inputs = results.inputs, outputs = results.outputs, 
                               bounds=bound, keys = keys , tol = "12")    
 
-        # When tolerance is empty list
+        # When tolerance is not passed in (default)
         m.parameters['thrower_height'] = 3.1
         m.parameters['throwing_speed'] = 29
         m.parameters['g'] = 10
-        m.estimate_params(times = results.times, inputs = results.inputs, outputs = results.outputs, keys = keys, tol = [])
+        m.estimate_params(times = results.times, inputs = results.inputs, outputs = results.outputs, keys = keys)
         hold1 = m.calc_error(results.times, results.inputs, results.outputs)
 
         # Tolerance works as intended as long as it is within a sequence of length 1


### PR DESCRIPTION
Update `tests_tolerance` to remove explicitly setting `tol` to an empty array since it no longer defaults to `False` in newer numpy version.

-----

We get the following error when we run tests_tolerance without the data-driven dependencies installed:

```
======================================================================
ERROR: test_tolerance (tests.test_estimate_params.TestEstimateParams)
Test which specifically targets adding tolerance as a keyword argument.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/mly1/Documents/temp/progpy/tests/test_estimate_params.py", line 964, in test_tolerance
    m.estimate_params(times = results.times, inputs = results.inputs, outputs = results.outputs, keys = keys, tol = [])
  File "/Users/mly1/Documents/temp/progpy/src/progpy/prognostics_model.py", line 1440, in estimate_params
    res = minimize(optimization_fcn, params, method=method, bounds=config['bounds'], options=config['options'], tol=config['tol'])
  File "/Users/mly1/Documents/temp/progpy/.venv2/lib/python3.10/site-packages/scipy/optimize/_minimize.py", line 726, in minimize
    res = _minimize_neldermead(fun, x0, args, callback, bounds=bounds,
  File "/Users/mly1/Documents/temp/progpy/.venv2/lib/python3.10/site-packages/scipy/optimize/_optimize.py", line 850, in _minimize_neldermead
    if (np.max(np.ravel(np.abs(sim[1:] - sim[0]))) <= xatol and
ValueError: The truth value of an empty array is ambiguous. Use `array.size > 0` to check that an array is not empty.
```

This is likely happening because of a numpy issue (buried under scipy). When installing with data-driven dependencies, we get numpy version `2.0.2` since it's compatible with tensorflow. In this case, the test runs fine. Without the data-driven dependencies, we install the latest version of numpy at `2.2.3` and the test fails.

In the error, the problematic part is that `tol = []` is an empty array.

This isn't the exact [error](https://github.com/scikit-learn/scikit-learn/issues/10449) but pretty close. This could potentially be the same behavior where the empty array in tol is no longer defaulting to False in the newer numpy version.

`DeprecationWarning: The truth value of an empty array is ambiguous. Returning False, but in future this will result in an error. Use array.size > 0 to check that an array is not empty.`

Since the overall test checks if tolerance is working as expected, there isn't a need to have tolerance explicitly set to an empty array. Note that `tol` is optional and defaults to `None`. It is therefore acceptable behavior for the user to get an error for passing in an empty array.