### PR TITLE
Allow thresholds_met_eqn argument to be passed into event_strategy in simulations

### DIFF
--- a/examples/01_Simulation.ipynb
+++ b/examples/01_Simulation.ipynb
@@ -379,7 +379,7 @@
    "source": [
     "Note that simulation stopped at around 3.8 seconds, about when the object starts falling.\n",
     "\n",
-    "Alternatively, if we would like to execute until all events have occurred, we can use the `event_strategy` argument, which specifies the strategy for stopping evaluation. The default value is `first`, but we can change it to `all` or a custom function, as shown below."
+    "Alternatively, if we would like to execute until all events have occurred, we can use the `event_strategy` argument, which specifies the strategy for stopping evaluation. The default value is `first`, but we can change it to `all`."
    ]
   },
   {
@@ -390,6 +390,15 @@
    "source": [
     "results = m.simulate_to_threshold(save_freq=0.5, dt=0.1, event_strategy='all')\n",
     "print('Last timestep: ', results.times[-1])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note the simulation stopped at around 7.9 seconds, when the last of the events occurred ('impact').\n",
+    "\n",
+    "We can also specify `event_strategy` to be a custom function."
    ]
   },
   {
@@ -412,7 +421,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note the simulation stopped at around 7.9 seconds, when the last of the events occurred ('impact').\n",
+    "Again, we can see that the simulation stopped at around 7.9 seconds, when the last of the events occurred ('impact').\n",
     "\n",
     "This is a basic example of simulating to an event. However, this is still just an example. Most models will have some form of input or loading. Simulating these models is described in the following section. The remainder of the sections go through various features for further customizing simulations."
    ]

--- a/examples/01_Simulation.ipynb
+++ b/examples/01_Simulation.ipynb
@@ -377,9 +377,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that simulation stopped at around 3.8 seconds, about when the object starts falling. \n",
+    "Note that simulation stopped at around 3.8 seconds, about when the object starts falling.\n",
     "\n",
-    "Alternately, if we would like to execute until all events have occurred, we can use the `event_strategy` argument."
+    "Alternatively, if we would like to execute until all events have occurred, we can use the `event_strategy` argument, which specifies the strategy for stopping evaluation. The default value is `first`, but we can change it to `all` or a custom function, as shown below."
    ]
   },
   {
@@ -389,6 +389,22 @@
    "outputs": [],
    "source": [
     "results = m.simulate_to_threshold(save_freq=0.5, dt=0.1, event_strategy='all')\n",
+    "print('Last timestep: ', results.times[-1])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from numpy import all\n",
+    "\n",
+    "# Custom function that stops when all objects impact ground\n",
+    "def thresholds_met_eqn(thresholds_met):\n",
+    "    return all(thresholds_met['impact'])\n",
+    "\n",
+    "results = m.simulate_to_threshold(save_freq=0.5, dt=0.1, event_strategy=thresholds_met_eqn)\n",
     "print('Last timestep: ', results.times[-1])"
    ]
   },

--- a/src/progpy/prognostics_model.py
+++ b/src/progpy/prognostics_model.py
@@ -964,7 +964,7 @@ class PrognosticsModel(ABC):
         elif callable(config['event_strategy']):
             check_thresholds = config['event_strategy']
         else:
-            raise ValueError(f"Invalid value for `event_strategy`: {config['event_strategy']}. Should 'all', 'first', or a function")
+            raise ValueError(f"Invalid value for `event_strategy`: {config['event_strategy']}. Should 'all', 'first', or a callable (e.g., function or lambda)")
 
         if 'thresholds_met_eqn' in config:
             warn('thresholds_met_eqn will be removed after version 1.7 of ProgPy. The thresholds_met_eqn argument can now be passed into event_strategy.',

--- a/src/progpy/prognostics_model.py
+++ b/src/progpy/prognostics_model.py
@@ -960,10 +960,14 @@ class PrognosticsModel(ABC):
                 if len(t_met) > 0 and not np.isscalar(list(t_met)[0]):
                     return np.all(t_met)
                 return all(t_met)
+        elif callable(config['event_strategy']):
+            check_thresholds = config['event_strategy']
         else:
             raise ValueError(f"Invalid value for `event_strategy`: {config['event_strategy']}. Should be either 'all' or 'first'")
 
         if 'thresholds_met_eqn' in config:
+            warn('thresholds_met_eqn will be removed after version 1.7 of ProgPy. The thresholds_met_eqn argument can now be passed into event_strategy.',
+                DeprecationWarning, stacklevel=2)
             check_thresholds = config['thresholds_met_eqn']
             events = []
         elif events is None: 

--- a/src/progpy/prognostics_model.py
+++ b/src/progpy/prognostics_model.py
@@ -963,7 +963,7 @@ class PrognosticsModel(ABC):
         elif callable(config['event_strategy']):
             check_thresholds = config['event_strategy']
         else:
-            raise ValueError(f"Invalid value for `event_strategy`: {config['event_strategy']}. Should be either 'all' or 'first'")
+            raise ValueError(f"Invalid value for `event_strategy`: {config['event_strategy']}. Should 'all', 'first', or a function")
 
         if 'thresholds_met_eqn' in config:
             warn('thresholds_met_eqn will be removed after version 1.7 of ProgPy. The thresholds_met_eqn argument can now be passed into event_strategy.',

--- a/src/progpy/prognostics_model.py
+++ b/src/progpy/prognostics_model.py
@@ -924,6 +924,8 @@ class PrognosticsModel(ABC):
             raise TypeError("'thresholds_met_eqn' must be callable (e.g., function or lambda)")
         if 'thresholds_met_eqn' in config and config['thresholds_met_eqn'].__code__.co_argcount != 1:
             raise ValueError("'thresholds_met_eqn' must accept one argument (thresholds)-> bool")
+        if 'event_strategy' in config and callable(config['event_strategy']) and config['event_strategy'].__code__.co_argcount != 1:
+            raise ValueError("'event_strategy' callable must accept one argument (thresholds)-> bool")
         if not isinstance(config['print'], bool):
             raise TypeError("'print' must be a bool, was a {}".format(type(config['print'])))
 

--- a/src/progpy/prognostics_model.py
+++ b/src/progpy/prognostics_model.py
@@ -786,10 +786,11 @@ class PrognosticsModel(ABC):
         events: abc.Sequence[str] or str, optional
             Keys for events that will trigger the end of simulation.
             If blank, simulation will occur if any event will be met ()
-        event_strategy: str, optional
+        event_strategy: str or abc.Callable, optional
             Strategy for stopping evaluation. Default is 'first'. One of:\n
             * *first*: Will stop when first event in `events` list is reached.\n
-            * *all*: Will stop when all events in `events` list have been reached
+            * *all*: Will stop when all events in `events` list have been reached\n
+            * *abc.Callable*: Custom equation to indicate logic for when to stop sim f(thresholds_met) -> bool
         t0 : float, optional
             Starting time for simulation in seconds (default: 0.0) \n
         dt : float, tuple, str, or function, optional

--- a/tests/test_base_models.py
+++ b/tests/test_base_models.py
@@ -629,15 +629,15 @@ class TestModels(unittest.TestCase):
         # Any event, manual - threshold met eqn - two arguments
         def thresh_met(thresholds, num):
             return thresholds.values() > num
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ValueError):
             (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(load, {'o1': 0.8}, dt=0.5, save_freq=1.0, events=['e1', 'e2'], event_strategy=thresh_met)
 
         # Any event, manual - threshold met eqn - no argument
         def thresh_met():
             return 1
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ValueError):
             (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(load, {'o1': 0.8}, dt=0.5, save_freq=1.0, events=['e1', 'e2'], event_strategy=thresh_met)
-
+            
         # Any event, manual - unexpected strategy
         with self.assertRaises(ValueError):
             (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(load, {'o1': 0.8}, dt=0.5, save_freq=1.0, events=['e1', 'e2'], event_strategy='fljsdk')

--- a/tests/test_base_models.py
+++ b/tests/test_base_models.py
@@ -620,6 +620,12 @@ class TestModels(unittest.TestCase):
         (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(load, {'o1': 0.8}, dt=0.5, save_freq=1.0, events=['e1', 'e2'], event_strategy='all')
         self.assertAlmostEqual(times[-1], 15.0, 5)
 
+        # both e1, e2 - threshold met eqn
+        def thresh_met(thresholds):
+            return all(thresholds.values())
+        (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(load, {'o1': 0.8}, dt=0.5, save_freq=1.0, events=['e1', 'e2'], event_strategy=thresh_met)
+        self.assertAlmostEqual(times[-1], 15.0, 5)
+
         # Any event, manual - unexpected strategy
         with self.assertRaises(ValueError):
             (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(load, {'o1': 0.8}, dt=0.5, save_freq=1.0, events=['e1', 'e2'], event_strategy='fljsdk')
@@ -654,11 +660,12 @@ class TestModels(unittest.TestCase):
         with self.assertRaises(ValueError):
             (times, inputs, states, outputs, event_states) = m_noevents.simulate_to_threshold(load, {'o1': 0.8}, dt=0.5, save_freq=1.0)
 
-        # Custom thresholds met eqn- both keys
+        # Custom thresholds met eqn - both keys
         def thresh_met(thresholds):
             return all(thresholds.values())
         config = {'dt': 0.5, 'save_freq': 1.0, 'horizon': 20.0, 'thresholds_met_eqn': thresh_met}
-        (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(load, {'o1': 0.8}, **config, events=['e1', 'e2'])
+        with self.assertWarns(Warning):
+            (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(load, {'o1': 0.8}, **config, events=['e1', 'e2'])
         self.assertAlmostEqual(times[-1], 15.0, 5)
 
         # With no events and no horizon, but a threshold met eqn

--- a/tests/test_base_models.py
+++ b/tests/test_base_models.py
@@ -626,6 +626,18 @@ class TestModels(unittest.TestCase):
         (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(load, {'o1': 0.8}, dt=0.5, save_freq=1.0, events=['e1', 'e2'], event_strategy=thresh_met)
         self.assertAlmostEqual(times[-1], 15.0, 5)
 
+        # Any event, manual - threshold met eqn - two arguments
+        def thresh_met(thresholds, num):
+            return thresholds.values() > num
+        with self.assertRaises(TypeError):
+            (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(load, {'o1': 0.8}, dt=0.5, save_freq=1.0, events=['e1', 'e2'], event_strategy=thresh_met)
+
+        # Any event, manual - threshold met eqn - no argument
+        def thresh_met():
+            return 1
+        with self.assertRaises(TypeError):
+            (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(load, {'o1': 0.8}, dt=0.5, save_freq=1.0, events=['e1', 'e2'], event_strategy=thresh_met)
+
         # Any event, manual - unexpected strategy
         with self.assertRaises(ValueError):
             (times, inputs, states, outputs, event_states) = m.simulate_to_threshold(load, {'o1': 0.8}, dt=0.5, save_freq=1.0, events=['e1', 'e2'], event_strategy='fljsdk')


### PR DESCRIPTION
Address https://github.com/nasa/progpy/issues/186 by allowing the `thresholds_met_eqn` to be passed into `event_strategy` when using `simulate_to_threshold`.  The `thresholds_met_eqn` will be removed after the next version of ProgPy.