### PR TITLE
Fix setting integration method

### DIFF
--- a/examples/01_Simulation.ipynb
+++ b/examples/01_Simulation.ipynb
@@ -1920,7 +1920,51 @@
    "source": [
     "Simulation is essentially the process of integrating a model forward with time. By default, a simple Euler integration is used to propagate the model forward. Advanced users can change the numerical integration method to affect the simulation accuracy and runtime. This is done using the `integration_method` argument in `simulate_to()`, `simulate_to_threshold()`, or the model parameters like `m.parameters['integration_method'] = 'rk4'`. Note that the integration method can only be changed for continuous models.\n",
     "\n",
-    "Let's look at an example of simulating with the default euler integration method and with the Runge-Kutta fourth-order (rk4) integration method.Simulating with a larger step size often results in less accurate models, and in this particular example, a step size of 2 is relatively large. After simulation, we will plot the voltage outputs."
+    "Let's look at an example of simulating with both the default Euler integration method and with the Runge-Kutta fourth-order (RK4) integration method. Since RK4 is a higher-order integration method, it is more accurate than a simple Euler integration. However, it is also more complex and therefore more computationally expensive. Let's compare the results of these two techniques.\n",
+    "\n",
+    "First, we'll integrate with a step size of 1. Here, we can see that the two integration techniques are nearly identical. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "config = {\n",
+    "    'save_freq': 10,\n",
+    "    'dt': 1,\n",
+    "}\n",
+    "\n",
+    "rk4_config = {\n",
+    "    'save_freq': 10,\n",
+    "    'dt': 1,\n",
+    "    'integration_method': 'rk4'\n",
+    "}\n",
+    "\n",
+    "simulated_results = batt.simulate_to_threshold(future_loading, **config)\n",
+    "rk4_simulated_results = batt.simulate_to_threshold(future_loading, **rk4_config)\n",
+    "\n",
+    "def plot_integration_method_comparison(simulated_results, rk4_simulated_results):\n",
+    "    euler_v = [o['v'] for o in simulated_results.outputs]\n",
+    "    rk4_v = [o['v'] for o in rk4_simulated_results.outputs]\n",
+    "\n",
+    "    plt.plot(simulated_results.times, euler_v)\n",
+    "    plt.plot(simulated_results.times, rk4_v, linestyle='dashed')\n",
+    "    plt.xlabel('time (s)')\n",
+    "    plt.ylabel('voltage (V)')\n",
+    "    plt.legend(['euler', 'rk4'])\n",
+    "\n",
+    "plot_integration_method_comparison(simulated_results, rk4_simulated_results)\n",
+    "plt.title('Simulation with step size 1 and euler vs. rk4 integration method', pad=10)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, let's increase the step size to 2. Note that simulating with a larger step size results in a less accurate simulation result. In this case, the lower-accuracy Euler method is becoming unstable, but the higher-order RK4 method is still resulting in an accurate solution."
    ]
   },
   {
@@ -1943,15 +1987,8 @@
     "simulated_results = batt.simulate_to_threshold(future_loading, **config)\n",
     "rk4_simulated_results = batt.simulate_to_threshold(future_loading, **rk4_config)\n",
     "\n",
-    "euler_v = [o['v'] for o in simulated_results.outputs]\n",
-    "rk4_v = [o['v'] for o in rk4_simulated_results.outputs]\n",
-    "\n",
-    "plt.plot(simulated_results.times, euler_v)\n",
-    "plt.plot(simulated_results.times, rk4_v, linestyle='dashed')\n",
-    "plt.xlabel('time (s)')\n",
-    "plt.ylabel('voltage (V)')\n",
-    "plt.legend(['euler', 'rk4'])\n",
-    "plt.title('Simulation with euler vs. rk4 integration method', pad=10)\n",
+    "plot_integration_method_comparison(simulated_results, rk4_simulated_results)\n",
+    "plt.title('Simulation with step size 2 and euler vs. rk4 integration method', pad=10)\n",
     "plt.show()"
    ]
   },

--- a/examples/01_Simulation.ipynb
+++ b/examples/01_Simulation.ipynb
@@ -1920,7 +1920,7 @@
    "source": [
     "Simulation is essentially the process of integrating a model forward with time. By default, a simple Euler integration is used to propagate the model forward. Advanced users can change the numerical integration method to affect the simulation quality and runtime. This is done using the `integration_method` argument in `simulate_to()`, `simulate_to_threshold()`, or the model parameters like `m.parameters['integration_method'] = 'rk4'`. Note that the integration method can only be changed for continuous models.\n",
     "\n",
-    "Let's look at an example of simulating with the default euler integration method and with the Runge-Kutta fourth-order (rk4) integration method. We will then print the last output values."
+    "Let's look at an example of simulating with the default euler integration method and with the Runge-Kutta fourth-order (rk4) integration method.Simulating with a larger step size often results in less accurate models, and in this particular example, a step size of 2 is relatively large. After simulation, we will plot the voltage outputs."
    ]
   },
   {
@@ -1930,12 +1930,12 @@
    "outputs": [],
    "source": [
     "config = {\n",
-    "    'save_freq': 100,\n",
+    "    'save_freq': 10,\n",
     "    'dt': 2,\n",
     "}\n",
     "\n",
     "rk4_config = {\n",
-    "    'save_freq': 100,\n",
+    "    'save_freq': 10,\n",
     "    'dt': 2,\n",
     "    'integration_method': 'rk4'\n",
     "}\n",
@@ -1943,15 +1943,23 @@
     "simulated_results = batt.simulate_to_threshold(future_loading, **config)\n",
     "rk4_simulated_results = batt.simulate_to_threshold(future_loading, **rk4_config)\n",
     "\n",
-    "print(\"euler simulation: \", simulated_results.outputs[-1])\n",
-    "print(\"rk4 simulation: \", rk4_simulated_results.outputs[-1])"
+    "euler_v = [o['v'] for o in simulated_results.outputs]\n",
+    "rk4_v = [o['v'] for o in rk4_simulated_results.outputs]\n",
+    "\n",
+    "plt.plot(simulated_results.times, euler_v)\n",
+    "plt.plot(simulated_results.times, rk4_v, linestyle='dashed')\n",
+    "plt.xlabel('time (s)')\n",
+    "plt.ylabel('voltage (V)')\n",
+    "plt.legend(['euler', 'rk4'])\n",
+    "plt.title('Simulation with euler vs. rk4 integration method', pad=10)\n",
+    "plt.show()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can see the output values of `t` and `v` differ based on the integration method."
+    "Based on the graph, we can see differences in voltage outputs between the two integration methods. We can see that the simulation using the `rk4` integration method produces a smoother and more accurate curve compared to the simulation using the `euler` integration method. This is expected, as `rk4` is a higher-order integration method than `euler` and is generally more accurate, albeit slower to simulate."
    ]
   },
   {

--- a/examples/01_Simulation.ipynb
+++ b/examples/01_Simulation.ipynb
@@ -1451,8 +1451,8 @@
     "def print_noise_plot(simulation):\n",
     "    noise_x = [state['x'] for state in simulation.states]\n",
     "    noise_v = [state['v'] for state in simulation.states]\n",
-    "    plt.plot(simulated_results.times, noise_x, label='Position (x) [m]', color='tab:blue')\n",
-    "    plt.plot(simulated_results.times, noise_v, label='Velocity (v) [m/s]', color='tab:orange')\n",
+    "    plt.plot(simulation.times, noise_x, label='Position (x) [m]', color='tab:blue')\n",
+    "    plt.plot(simulation.times, noise_v, label='Velocity (v) [m/s]', color='tab:orange')\n",
     "    plt.legend()"
    ]
   },
@@ -1877,9 +1877,9 @@
     "    't0': 700,\n",
     "}\n",
     "\n",
-    "print(\"First timestamp in simulation :\", simulated_results.times[0])\n",
-    "\n",
     "simulated_results = batt.simulate_to_threshold(future_loading, **config)\n",
+    "\n",
+    "print(\"First timestamp in simulation :\", simulated_results.times[0])\n",
     "\n",
     "simulated_results.inputs.plot(xlabel='time (s)', ylabel='current draw (amps)')\n",
     "plt.scatter(simulated_results.times[0], simulated_results.inputs[0]['i'], color='red', zorder=5)\n",
@@ -1918,7 +1918,40 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Simulation is essentially the process of integrating a model forward with time. By default, a simple Euler integration is used to propagate the model forward. Advanced users can change the numerical integration method to affect the simulation quality and runtime. This is done using the `integration_method` argument in `simulate_to()`, `simulate_to_threshold()`, or the model parameters like `m.parameters['integration_method'] = 'rk4'`."
+    "Simulation is essentially the process of integrating a model forward with time. By default, a simple Euler integration is used to propagate the model forward. Advanced users can change the numerical integration method to affect the simulation quality and runtime. This is done using the `integration_method` argument in `simulate_to()`, `simulate_to_threshold()`, or the model parameters like `m.parameters['integration_method'] = 'rk4'`. Note that the integration method can only be changed for continuous models.\n",
+    "\n",
+    "Let's look at an example of simulating with the default euler integration method and with the Runge-Kutta fourth-order (rk4) integration method. We will then print the last output values."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "config = {\n",
+    "    'save_freq': 100,\n",
+    "    'dt': 2,\n",
+    "}\n",
+    "\n",
+    "rk4_config = {\n",
+    "    'save_freq': 100,\n",
+    "    'dt': 2,\n",
+    "    'integration_method': 'rk4'\n",
+    "}\n",
+    "\n",
+    "simulated_results = batt.simulate_to_threshold(future_loading, **config)\n",
+    "rk4_simulated_results = batt.simulate_to_threshold(future_loading, **rk4_config)\n",
+    "\n",
+    "print(\"euler simulation: \", simulated_results.outputs[-1])\n",
+    "print(\"rk4 simulation: \", rk4_simulated_results.outputs[-1])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can see the output values of `t` and `v` differ based on the integration method."
    ]
   },
   {

--- a/examples/01_Simulation.ipynb
+++ b/examples/01_Simulation.ipynb
@@ -1953,10 +1953,10 @@
     "    plt.plot(simulated_results.times, rk4_v, linestyle='dashed')\n",
     "    plt.xlabel('time (s)')\n",
     "    plt.ylabel('voltage (V)')\n",
-    "    plt.legend(['euler', 'rk4'])\n",
+    "    plt.legend(['Euler', 'RK4'])\n",
     "\n",
     "plot_integration_method_comparison(simulated_results, rk4_simulated_results)\n",
-    "plt.title('Simulation with step size 1 and euler vs. rk4 integration method', pad=10)\n",
+    "plt.title('Simulation with step size 1 and Euler vs. RK4 integration method', pad=10)\n",
     "plt.show()"
    ]
   },
@@ -1988,7 +1988,7 @@
     "rk4_simulated_results = batt.simulate_to_threshold(future_loading, **rk4_config)\n",
     "\n",
     "plot_integration_method_comparison(simulated_results, rk4_simulated_results)\n",
-    "plt.title('Simulation with step size 2 and euler vs. rk4 integration method', pad=10)\n",
+    "plt.title('Simulation with step size 2 and Euler vs. RK4 integration method', pad=10)\n",
     "plt.show()"
    ]
   },

--- a/examples/01_Simulation.ipynb
+++ b/examples/01_Simulation.ipynb
@@ -1918,7 +1918,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Simulation is essentially the process of integrating a model forward with time. By default, a simple Euler integration is used to propagate the model forward. Advanced users can change the numerical integration method to affect the simulation quality and runtime. This is done using the `integration_method` argument in `simulate_to()`, `simulate_to_threshold()`, or the model parameters like `m.parameters['integration_method'] = 'rk4'`. Note that the integration method can only be changed for continuous models.\n",
+    "Simulation is essentially the process of integrating a model forward with time. By default, a simple Euler integration is used to propagate the model forward. Advanced users can change the numerical integration method to affect the simulation accuracy and runtime. This is done using the `integration_method` argument in `simulate_to()`, `simulate_to_threshold()`, or the model parameters like `m.parameters['integration_method'] = 'rk4'`. Note that the integration method can only be changed for continuous models.\n",
     "\n",
     "Let's look at an example of simulating with the default euler integration method and with the Runge-Kutta fourth-order (rk4) integration method.Simulating with a larger step size often results in less accurate models, and in this particular example, a step size of 2 is relatively large. After simulation, we will plot the voltage outputs."
    ]
@@ -1959,7 +1959,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Based on the graph, we can see differences in voltage outputs between the two integration methods. We can see that the simulation using the `rk4` integration method produces a smoother and more accurate curve compared to the simulation using the `euler` integration method. This is expected, as `rk4` is a higher-order integration method than `euler` and is generally more accurate, albeit slower to simulate."
+    "Based on the graph, we can see differences in voltage outputs between the two integration methods. We can see that the simulation using the `RK4` integration method produces a smoother and more accurate curve compared to the simulation using the `Euler` integration method. This is expected, as `RK4` is a higher-order integration method than `Euler` and is generally more accurate, albeit slower to simulate."
    ]
   },
   {

--- a/src/progpy/prognostics_model.py
+++ b/src/progpy/prognostics_model.py
@@ -939,6 +939,11 @@ class PrognosticsModel(ABC):
 
         if not isinstance(x, self.StateContainer):
             x = self.StateContainer(x)
+
+        if 'integration_method' in config:
+            # Update integration method for the duration of the simulation
+            old_integration_method = self.parameters.get('integration_method', 'euler')
+            self.parameters['integration_method'] = config['integration_method']
         
         # Optimization
         output = self.__output
@@ -1090,11 +1095,6 @@ class PrognosticsModel(ABC):
             simulate_progress = ProgressBar(100, "Progress")
             last_percentage = 0
 
-        if 'integration_method' in config:
-            # Update integration method for the duration of the simulation
-            old_integration_method = self.parameters.get('integration_method', 'euler')
-            self.parameters['integration_method'] = config['integration_method']
-       
         while t < horizon:
             dt_i = next_time(t, x)
             t_load = t + dt_i/2  # Saving as separate variable reduces likelihood of floating point error

--- a/tests/test_base_models.py
+++ b/tests/test_base_models.py
@@ -997,6 +997,13 @@ class TestModels(unittest.TestCase):
         result = m.simulate_to_threshold(load, dt = 0.1, integration_method='rk4')
         self.assertAlmostEqual(result.times[-1], 8.3)
 
+    def test_integration_sim(self):
+        m = LinearThrownObject(process_noise=0, measurement_noise=0)
+
+        default_result = m.simulate_to_threshold(dt = 0.1)
+        rk4_result = m.simulate_to_threshold(dt = 0.1, integration_method='rk4')
+        self.assertNotEqual(rk4_result.outputs[-1]['x'], default_result.outputs[-1]['x'])
+
     # when range specified when state doesn't exist or entered incorrectly
     def test_state_limits(self):
         m = MockProgModel()


### PR DESCRIPTION
Address https://github.com/nasa/progpy/issues/187 where the integration method was not being set properly. 

Issue was that the integration method was set after storing the object (`self.next_state`) values in local variables for optimization. Solved by setting the integration method before saving local variables.

Add integration method example to simulation notebook and fix related miscellaneous issues.