### PR TITLE
Upgrade workflow cache and python version

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,7 +20,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: pip-cache-datadriven

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,7 +20,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: pip-cache-datadriven

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7'
+        python-version: '3.8'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -36,7 +36,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7'
+        python-version: '3.8'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -54,7 +54,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7'
+        python-version: '3.8'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -72,7 +72,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7'
+        python-version: '3.8'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -90,7 +90,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7'
+        python-version: '3.8'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -108,7 +108,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7'
+        python-version: '3.8'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -126,7 +126,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7'
+        python-version: '3.8'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -146,7 +146,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7'
+        python-version: '3.8'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -164,7 +164,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7'
+        python-version: '3.8'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -182,7 +182,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7'
+        python-version: '3.8'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -200,7 +200,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7'
+        python-version: '3.8'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -218,7 +218,7 @@ jobs:
   #   - name: Set up Python
   #     uses: actions/setup-python@v4
   #     with:
-  #       python-version: '3.7'
+  #       python-version: '3.8'
   #   - name: Install dependencies cache
   #     uses: actions/cache@v4
   #     with:
@@ -236,7 +236,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7'
+        python-version: '3.8'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -254,7 +254,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7'
+        python-version: '3.8'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -272,7 +272,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7'
+        python-version: '3.8'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -290,7 +290,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7'
+        python-version: '3.8'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -308,7 +308,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7'
+        python-version: '3.8'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -326,7 +326,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7'
+        python-version: '3.8'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -344,7 +344,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7'
+        python-version: '3.8'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -362,7 +362,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7'
+        python-version: '3.8'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -380,7 +380,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7'
+        python-version: '3.8'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -398,7 +398,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7'
+        python-version: '3.8'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -416,7 +416,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7'
+        python-version: '3.8'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -434,7 +434,7 @@ jobs:
   #   - name: Set up Python
   #     uses: actions/setup-python@v4
   #     with:
-  #       python-version: '3.7'
+  #       python-version: '3.8'
   #   - name: Install dependencies cache
   #     uses: actions/cache@v4
   #     with:
@@ -455,7 +455,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7'
+        python-version: '3.8'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -473,7 +473,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7'
+        python-version: '3.8'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7.10'
+        python-version: '3.7'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -36,7 +36,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7.10'
+        python-version: '3.7'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -54,7 +54,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7.10'
+        python-version: '3.7'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -72,7 +72,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7.10'
+        python-version: '3.7'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -90,7 +90,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7.10'
+        python-version: '3.7'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -108,7 +108,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7.10'
+        python-version: '3.7'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -126,7 +126,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7.10'
+        python-version: '3.7'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -146,7 +146,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7.10'
+        python-version: '3.7'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -164,7 +164,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7.10'
+        python-version: '3.7'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -182,7 +182,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7.10'
+        python-version: '3.7'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -200,7 +200,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7.10'
+        python-version: '3.7'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -218,7 +218,7 @@ jobs:
   #   - name: Set up Python
   #     uses: actions/setup-python@v4
   #     with:
-  #       python-version: '3.7.10'
+  #       python-version: '3.7'
   #   - name: Install dependencies cache
   #     uses: actions/cache@v4
   #     with:
@@ -236,7 +236,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7.10'
+        python-version: '3.7'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -254,7 +254,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7.10'
+        python-version: '3.7'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -272,7 +272,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7.10'
+        python-version: '3.7'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -290,7 +290,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7.10'
+        python-version: '3.7'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -308,7 +308,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7.10'
+        python-version: '3.7'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -326,7 +326,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7.10'
+        python-version: '3.7'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -344,7 +344,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7.10'
+        python-version: '3.7'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -362,7 +362,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7.10'
+        python-version: '3.7'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -380,7 +380,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7.10'
+        python-version: '3.7'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -398,7 +398,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7.10'
+        python-version: '3.7'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -416,7 +416,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7.10'
+        python-version: '3.7'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -434,7 +434,7 @@ jobs:
   #   - name: Set up Python
   #     uses: actions/setup-python@v4
   #     with:
-  #       python-version: '3.7.10'
+  #       python-version: '3.7'
   #   - name: Install dependencies cache
   #     uses: actions/cache@v4
   #     with:
@@ -455,7 +455,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7.10'
+        python-version: '3.7'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -473,7 +473,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7.10'
+        python-version: '3.7'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7'
+        python-version: '3.7.1'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -36,7 +36,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7'
+        python-version: '3.7.1'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -54,7 +54,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7'
+        python-version: '3.7.1'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -72,7 +72,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7'
+        python-version: '3.7.1'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -90,7 +90,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7'
+        python-version: '3.7.1'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -108,7 +108,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7'
+        python-version: '3.7.1'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -126,7 +126,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7'
+        python-version: '3.7.1'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -146,7 +146,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7'
+        python-version: '3.7.1'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -164,7 +164,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7'
+        python-version: '3.7.1'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -182,7 +182,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7'
+        python-version: '3.7.1'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -200,7 +200,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7'
+        python-version: '3.7.1'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -218,7 +218,7 @@ jobs:
   #   - name: Set up Python
   #     uses: actions/setup-python@v4
   #     with:
-  #       python-version: '3.7'
+  #       python-version: '3.7.1'
   #   - name: Install dependencies cache
   #     uses: actions/cache@v4
   #     with:
@@ -236,7 +236,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7'
+        python-version: '3.7.1'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -254,7 +254,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7'
+        python-version: '3.7.1'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -272,7 +272,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7'
+        python-version: '3.7.1'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -290,7 +290,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7'
+        python-version: '3.7.1'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -308,7 +308,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7'
+        python-version: '3.7.1'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -326,7 +326,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7'
+        python-version: '3.7.1'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -344,7 +344,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7'
+        python-version: '3.7.1'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -362,7 +362,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7'
+        python-version: '3.7.1'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -380,7 +380,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7'
+        python-version: '3.7.1'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -398,7 +398,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7'
+        python-version: '3.7.1'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -416,7 +416,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7'
+        python-version: '3.7.1'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -434,7 +434,7 @@ jobs:
   #   - name: Set up Python
   #     uses: actions/setup-python@v4
   #     with:
-  #       python-version: '3.7'
+  #       python-version: '3.7.1'
   #   - name: Install dependencies cache
   #     uses: actions/cache@v4
   #     with:
@@ -455,7 +455,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7'
+        python-version: '3.7.1'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -473,7 +473,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7'
+        python-version: '3.7.1'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.8'
+        python-version: '3.9'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -36,7 +36,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.8'
+        python-version: '3.9'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -54,7 +54,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.8'
+        python-version: '3.9'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -72,7 +72,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.8'
+        python-version: '3.9'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -90,7 +90,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.8'
+        python-version: '3.9'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -108,7 +108,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.8'
+        python-version: '3.9'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -126,7 +126,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.8'
+        python-version: '3.9'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -146,7 +146,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.8'
+        python-version: '3.9'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -164,7 +164,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.8'
+        python-version: '3.9'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -182,7 +182,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.8'
+        python-version: '3.9'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -200,7 +200,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.8'
+        python-version: '3.9'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -218,7 +218,7 @@ jobs:
   #   - name: Set up Python
   #     uses: actions/setup-python@v4
   #     with:
-  #       python-version: '3.8'
+  #       python-version: '3.9'
   #   - name: Install dependencies cache
   #     uses: actions/cache@v4
   #     with:
@@ -236,7 +236,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.8'
+        python-version: '3.9'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -254,7 +254,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.8'
+        python-version: '3.9'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -272,7 +272,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.8'
+        python-version: '3.9'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -290,7 +290,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.8'
+        python-version: '3.9'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -308,7 +308,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.8'
+        python-version: '3.9'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -326,7 +326,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.8'
+        python-version: '3.9'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -344,7 +344,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.8'
+        python-version: '3.9'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -362,7 +362,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.8'
+        python-version: '3.9'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -380,7 +380,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.8'
+        python-version: '3.9'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -398,7 +398,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.8'
+        python-version: '3.9'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -416,7 +416,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.8'
+        python-version: '3.9'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -434,7 +434,7 @@ jobs:
   #   - name: Set up Python
   #     uses: actions/setup-python@v4
   #     with:
-  #       python-version: '3.8'
+  #       python-version: '3.9'
   #   - name: Install dependencies cache
   #     uses: actions/cache@v4
   #     with:
@@ -455,7 +455,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.8'
+        python-version: '3.9'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -473,7 +473,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.8'
+        python-version: '3.9'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7.1'
+        python-version: '3.7.10'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -36,7 +36,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7.1'
+        python-version: '3.7.10'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -54,7 +54,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7.1'
+        python-version: '3.7.10'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -72,7 +72,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7.1'
+        python-version: '3.7.10'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -90,7 +90,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7.1'
+        python-version: '3.7.10'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -108,7 +108,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7.1'
+        python-version: '3.7.10'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -126,7 +126,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7.1'
+        python-version: '3.7.10'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -146,7 +146,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7.1'
+        python-version: '3.7.10'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -164,7 +164,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7.1'
+        python-version: '3.7.10'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -182,7 +182,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7.1'
+        python-version: '3.7.10'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -200,7 +200,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7.1'
+        python-version: '3.7.10'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -218,7 +218,7 @@ jobs:
   #   - name: Set up Python
   #     uses: actions/setup-python@v4
   #     with:
-  #       python-version: '3.7.1'
+  #       python-version: '3.7.10'
   #   - name: Install dependencies cache
   #     uses: actions/cache@v4
   #     with:
@@ -236,7 +236,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7.1'
+        python-version: '3.7.10'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -254,7 +254,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7.1'
+        python-version: '3.7.10'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -272,7 +272,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7.1'
+        python-version: '3.7.10'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -290,7 +290,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7.1'
+        python-version: '3.7.10'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -308,7 +308,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7.1'
+        python-version: '3.7.10'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -326,7 +326,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7.1'
+        python-version: '3.7.10'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -344,7 +344,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7.1'
+        python-version: '3.7.10'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -362,7 +362,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7.1'
+        python-version: '3.7.10'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -380,7 +380,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7.1'
+        python-version: '3.7.10'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -398,7 +398,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7.1'
+        python-version: '3.7.10'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -416,7 +416,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7.1'
+        python-version: '3.7.10'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -434,7 +434,7 @@ jobs:
   #   - name: Set up Python
   #     uses: actions/setup-python@v4
   #     with:
-  #       python-version: '3.7.1'
+  #       python-version: '3.7.10'
   #   - name: Install dependencies cache
   #     uses: actions/cache@v4
   #     with:
@@ -455,7 +455,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7.1'
+        python-version: '3.7.10'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:
@@ -473,7 +473,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7.1'
+        python-version: '3.7.10'
     - name: Install dependencies cache
       uses: actions/cache@v4
       with:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -20,7 +20,7 @@ jobs:
       with:
         python-version: '3.7'
     - name: Install dependencies cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: pip-cache
@@ -38,7 +38,7 @@ jobs:
       with:
         python-version: '3.7'
     - name: Install dependencies cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: pip-cache
@@ -56,7 +56,7 @@ jobs:
       with:
         python-version: '3.7'
     - name: Install dependencies cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: pip-cache
@@ -74,7 +74,7 @@ jobs:
       with:
         python-version: '3.7'
     - name: Install dependencies cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: pip-cache
@@ -92,7 +92,7 @@ jobs:
       with:
         python-version: '3.7'
     - name: Install dependencies cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: pip-cache
@@ -110,7 +110,7 @@ jobs:
       with:
         python-version: '3.7'
     - name: Install dependencies cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: pip-cache-datadriven
@@ -128,7 +128,7 @@ jobs:
       with:
         python-version: '3.7'
     - name: Install dependencies cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: pip-cache
@@ -148,7 +148,7 @@ jobs:
       with:
         python-version: '3.7'
     - name: Install dependencies cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: pip-cache
@@ -166,7 +166,7 @@ jobs:
       with:
         python-version: '3.7'
     - name: Install dependencies cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: pip-cache
@@ -184,7 +184,7 @@ jobs:
       with:
         python-version: '3.7'
     - name: Install dependencies cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: pip-cache
@@ -202,7 +202,7 @@ jobs:
       with:
         python-version: '3.7'
     - name: Install dependencies cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: pip-cache
@@ -220,7 +220,7 @@ jobs:
   #     with:
   #       python-version: '3.7'
   #   - name: Install dependencies cache
-  #     uses: actions/cache@v3
+  #     uses: actions/cache@v4
   #     with:
   #       path: ~/.cache/pip
   #       key: pip-cache
@@ -238,7 +238,7 @@ jobs:
       with:
         python-version: '3.7'
     - name: Install dependencies cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: pip-cache
@@ -256,7 +256,7 @@ jobs:
       with:
         python-version: '3.7'
     - name: Install dependencies cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: pip-cache
@@ -274,7 +274,7 @@ jobs:
       with:
         python-version: '3.7'
     - name: Install dependencies cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: pip-cache
@@ -292,7 +292,7 @@ jobs:
       with:
         python-version: '3.7'
     - name: Install dependencies cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: pip-cache
@@ -310,7 +310,7 @@ jobs:
       with:
         python-version: '3.7'
     - name: Install dependencies cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: pip-cache
@@ -328,7 +328,7 @@ jobs:
       with:
         python-version: '3.7'
     - name: Install dependencies cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: pip-cache
@@ -346,7 +346,7 @@ jobs:
       with:
         python-version: '3.7'
     - name: Install dependencies cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: pip-cache
@@ -364,7 +364,7 @@ jobs:
       with:
         python-version: '3.7'
     - name: Install dependencies cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: pip-cache
@@ -382,7 +382,7 @@ jobs:
       with:
         python-version: '3.7'
     - name: Install dependencies cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: pip-cache
@@ -400,7 +400,7 @@ jobs:
       with:
         python-version: '3.7'
     - name: Install dependencies cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: pip-cache
@@ -418,7 +418,7 @@ jobs:
       with:
         python-version: '3.7'
     - name: Install dependencies cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: pip-cache-datadriven
@@ -436,7 +436,7 @@ jobs:
   #     with:
   #       python-version: '3.7'
   #   - name: Install dependencies cache
-  #     uses: actions/cache@v3
+  #     uses: actions/cache@v4
   #     with:
   #       path: ~/.cache/pip
   #       key: pip-cache-datadriven
@@ -457,7 +457,7 @@ jobs:
       with:
         python-version: '3.7'
     - name: Install dependencies cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: pip-cache
@@ -475,7 +475,7 @@ jobs:
       with:
         python-version: '3.7'
     - name: Install dependencies cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: pip-cache

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -20,7 +20,7 @@ jobs:
       with:
         python-version: '3.7'
     - name: Install dependencies cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: pip-cache
@@ -38,7 +38,7 @@ jobs:
       with:
         python-version: '3.7'
     - name: Install dependencies cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: pip-cache
@@ -56,7 +56,7 @@ jobs:
       with:
         python-version: '3.7'
     - name: Install dependencies cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: pip-cache
@@ -74,7 +74,7 @@ jobs:
       with:
         python-version: '3.7'
     - name: Install dependencies cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: pip-cache
@@ -92,7 +92,7 @@ jobs:
       with:
         python-version: '3.7'
     - name: Install dependencies cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: pip-cache
@@ -110,7 +110,7 @@ jobs:
       with:
         python-version: '3.7'
     - name: Install dependencies cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: pip-cache-datadriven
@@ -128,7 +128,7 @@ jobs:
       with:
         python-version: '3.7'
     - name: Install dependencies cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: pip-cache
@@ -148,7 +148,7 @@ jobs:
       with:
         python-version: '3.7'
     - name: Install dependencies cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: pip-cache
@@ -166,7 +166,7 @@ jobs:
       with:
         python-version: '3.7'
     - name: Install dependencies cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: pip-cache
@@ -184,7 +184,7 @@ jobs:
       with:
         python-version: '3.7'
     - name: Install dependencies cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: pip-cache
@@ -202,7 +202,7 @@ jobs:
       with:
         python-version: '3.7'
     - name: Install dependencies cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: pip-cache
@@ -220,7 +220,7 @@ jobs:
   #     with:
   #       python-version: '3.7'
   #   - name: Install dependencies cache
-  #     uses: actions/cache@v2
+  #     uses: actions/cache@v3
   #     with:
   #       path: ~/.cache/pip
   #       key: pip-cache
@@ -238,7 +238,7 @@ jobs:
       with:
         python-version: '3.7'
     - name: Install dependencies cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: pip-cache
@@ -256,7 +256,7 @@ jobs:
       with:
         python-version: '3.7'
     - name: Install dependencies cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: pip-cache
@@ -274,7 +274,7 @@ jobs:
       with:
         python-version: '3.7'
     - name: Install dependencies cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: pip-cache
@@ -292,7 +292,7 @@ jobs:
       with:
         python-version: '3.7'
     - name: Install dependencies cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: pip-cache
@@ -310,7 +310,7 @@ jobs:
       with:
         python-version: '3.7'
     - name: Install dependencies cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: pip-cache
@@ -328,7 +328,7 @@ jobs:
       with:
         python-version: '3.7'
     - name: Install dependencies cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: pip-cache
@@ -346,7 +346,7 @@ jobs:
       with:
         python-version: '3.7'
     - name: Install dependencies cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: pip-cache
@@ -364,7 +364,7 @@ jobs:
       with:
         python-version: '3.7'
     - name: Install dependencies cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: pip-cache
@@ -382,7 +382,7 @@ jobs:
       with:
         python-version: '3.7'
     - name: Install dependencies cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: pip-cache
@@ -400,7 +400,7 @@ jobs:
       with:
         python-version: '3.7'
     - name: Install dependencies cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: pip-cache
@@ -418,7 +418,7 @@ jobs:
       with:
         python-version: '3.7'
     - name: Install dependencies cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: pip-cache-datadriven
@@ -436,7 +436,7 @@ jobs:
   #     with:
   #       python-version: '3.7'
   #   - name: Install dependencies cache
-  #     uses: actions/cache@v2
+  #     uses: actions/cache@v3
   #     with:
   #       path: ~/.cache/pip
   #       key: pip-cache-datadriven
@@ -457,7 +457,7 @@ jobs:
       with:
         python-version: '3.7'
     - name: Install dependencies cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: pip-cache
@@ -475,7 +475,7 @@ jobs:
       with:
         python-version: '3.7'
     - name: Install dependencies cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: pip-cache

--- a/.github/workflows/update-cache.yml
+++ b/.github/workflows/update-cache.yml
@@ -20,7 +20,7 @@ jobs:
         python -m pip install notebook
         python -m pip install testbook
         python -m pip install requests
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: pip-cache
@@ -44,7 +44,7 @@ jobs:
         python -m pip install notebook
         python -m pip install testbook
         python -m pip install requests
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: pip-cache-datadriven


### PR DESCRIPTION
Address https://github.com/nasa/progpy/issues/185 on failing pipeline. 

- Failed pipeline run shows `Error: Missing download info for actions/cache@v2`.
- Failed pipeline run then shows the following error:
```
Version 3.7 was not found in the local cache
  Error: The version '3.7' with architecture 'x64' was not found for Ubuntu 24.04.
  The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
```

Resolved through the following actions:
- Upgrade cache `v2` to `v4` since the former was [deprecated](https://github.com/actions/cache?tab=readme-ov-file).
- Upgraded python `3.7` to `3.9` since version `3.7` is no longer supported and is a [known issue](https://github.com/actions/setup-python/issues/962).