### PR TITLE
Fix event_state saving without intermediate printing

### DIFF
--- a/src/progpy/prognostics_model.py
+++ b/src/progpy/prognostics_model.py
@@ -1020,6 +1020,7 @@ class PrognosticsModel(ABC):
                 saved_times.append(t)
                 saved_inputs.append(u)
                 saved_states.append(deepcopy(x))  # Avoid optimization where x is not copied
+                saved_event_states.append(event_state(x))
 
         # configuring next_time function to define prediction time step, default is constant dt
         if callable(config['dt']):
@@ -1137,11 +1138,9 @@ class PrognosticsModel(ABC):
         if not saved_outputs:
             # saved_outputs is empty, so it wasn't calculated in simulation - used cached result
             saved_outputs = LazySimResult(self.__output, saved_times, saved_states) 
-            saved_event_states = LazySimResult(self.event_state, saved_times, saved_states)
         else:
             saved_outputs = SimResult(saved_times, saved_outputs, _copy=False)
-            saved_event_states = SimResult(saved_times, saved_event_states, _copy=False)
-
+        
         if 'integration_method' in config:
             # Reset integration method
             self.parameters['integration_method'] = old_integration_method
@@ -1151,7 +1150,7 @@ class PrognosticsModel(ABC):
             SimResult(saved_times, saved_inputs, _copy=False), 
             SimResult(saved_times, saved_states, _copy=False), 
             saved_outputs, 
-            saved_event_states
+            SimResult(saved_times, saved_event_states, _copy=False)
         )
 
     def __sizeof__(self):


### PR DESCRIPTION
Address issue https://github.com/nasa/progpy/issues/199  with `event_state` calculation without intermediate printing. Implement **[Option 2]** to calculate `event_state` during the simulation and not as needed from `LazySim`.