### PR TITLE
Updating supported python versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "fastdtw",  # For DTW error calculation
     "filterpy>=1.4.4",
 ]
-requires-python = ">=3.7, <3.13"
+requires-python = ">=3.9, <3.14"
 authors = [
     {name = "Christopher Teubert", email = "christopher.a.teubert@nasa.gov"},
     {name = "Katelyn Griffith", email = "katelyn.j.griffith@nasa.gov"},
@@ -45,12 +45,11 @@ classifiers = [
     'License :: Other/Proprietary License ',
 
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.7',
-    'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
     'Programming Language :: Python :: 3 :: Only'
 ]
 

--- a/sphinx-config/troubleshooting.rst
+++ b/sphinx-config/troubleshooting.rst
@@ -30,4 +30,4 @@ If you are using data-driven tools (e.g., LSTM model), make sure the datadriven 
 
 Installing ProgPy Data-Driven Tools with Python 3.13
 ------------------------
-Tensorflow does not support python3.13 as of the writing of this. Until this is fixed, ProgPy data-driven features may not work correctly. If you are having trouble running data-driven features with Python3.13, try with an earlier version of Python.
+Tensorflow does not support Python3.13 as of the writing of this (April 2025). Until this is fixed, ProgPy data-driven features may not work correctly. If you are having trouble running data-driven features with Python3.13, try with an earlier version of Python.

--- a/sphinx-config/troubleshooting.rst
+++ b/sphinx-config/troubleshooting.rst
@@ -27,3 +27,7 @@ If you are using data-driven tools (e.g., LSTM model), make sure the datadriven 
         .. code-block:: console
 
             $ pip install -e '.[datadriven]'
+
+Installing ProgPy Data-Driven Tools with Python 3.13
+------------------------
+Tensorflow does not support python3.13 as of the writing of this. Until this is fixed, ProgPy data-driven features may not work correctly. If you are having trouble running data-driven features with Python3.13, try with an earlier version of Python.


### PR DESCRIPTION
Updating the supported python versions to drop 3.7 and 3.8 which are no longer actively supported by python (see https://devguide.python.org/versions/). ProgPy development policy is to not support versions once they reach python end-of-life.

This release also adds support for python 3.13 for all but data-driven features. A note is added to the troubleshooting guide for users using python3.13 with datadriven features.