### PR TITLE
Refactors deprecated warnings

### DIFF
--- a/src/progpy/metrics/samples.py
+++ b/src/progpy/metrics/samples.py
@@ -27,16 +27,3 @@ def root_mean_square_error(values, ground_truth):
         float: root mean square error of ToE predictions
     """
     return sqrt(sum([(mean(x) - ground_truth)**2 for x in values])/len(values))
-
-def percentage_in_bounds(toe: list, bounds: tuple) -> float:
-    """Calculate percentage of ToE dist is within specified bounds
-
-    Args:
-        toe (List[float]): Times of Event (ToE) for a single event, output from predictor
-        bounds ((float, float)): Lower and upper bounds
-
-    Returns:
-        float: Percentage within bounds (where 1 = 100%)
-    """
-    warn('percentage_in_bounds has been deprecated in favor of UncertainData.percentage_in_bounds(bounds). This function will be removed in a future release')
-    return sum([x < bounds[1] and x > bounds[0] for x in toe])/ len(toe)

--- a/src/progpy/sim_result.py
+++ b/src/progpy/sim_result.py
@@ -34,23 +34,23 @@ class SimResult(UserList):
             else:
                 self.data = data
 
-    def __getitem__(self, item):
-        """
-            created for deprecation warning. [] continues to be handled by parent
-        """
-        warn_once('[] for access by row number will be deprecated after version 1.5 of ProgPy. After v1.5, [] will access by column (e.g., data[\'state1\']), Users may use \'iloc\' to access by row number (e.g., data.iloc[10])'
-            'data by element.', DeprecationWarning, stacklevel=2)
-        return super().__getitem__(item)
+    # def __getitem__(self, item):
+    #     """
+    #         created for deprecation warning. [] continues to be handled by parent
+    #     """
+    #     warn_once('[] for access by row number will be deprecated after version 1.5 of ProgPy. After v1.5, [] will access by column (e.g., data[\'state1\']), Users may use \'iloc\' to access by row number (e.g., data.iloc[10])'
+    #         'data by element.', DeprecationWarning, stacklevel=2)
+    #     return super().__getitem__(item)
     
-    def __iter__(self):
-        """
-            created for deprecation warning. iteration continues to be handled by parent
-        """
-        warn_once(
-            'iteration will be deprecated after version 1.5 of ProgPy. The function will be renamed, iterrows, '
-            'and users may begin using it under this name now.',
-            DeprecationWarning, stacklevel=2)
-        return super().__iter__()
+    # def __iter__(self):
+    #     """
+    #         created for deprecation warning. iteration continues to be handled by parent
+    #     """
+    #     warn_once(
+    #         'iteration will be deprecated after version 1.5 of ProgPy. The function will be renamed, iterrows, '
+    #         'and users may begin using it under this name now.',
+    #         DeprecationWarning, stacklevel=2)
+    #     return super().__iter__()
     
     def iterrows(self):
         """
@@ -68,7 +68,7 @@ class SimResult(UserList):
             pd.DataFrame: A pandas DataFrame representing the SimResult data
         """
         # warn_once('frame will be deprecated after version 1.5 of ProgPy.', DeprecationWarning, stacklevel=2)
-        if len(self.data) > 0:
+        if len(self.data) > 0:  #
             frame = pd.concat([
                 pd.DataFrame(dict(dframe), index=[0]) for dframe in self.data
             ], ignore_index=True, axis=0)
@@ -147,10 +147,10 @@ class SimResult(UserList):
         Returns:
             bool: If the two SimResults are equal
         """
-        warn_once(
-            ' \' == \' will be deprecated after version 1.5 of ProgPy. The function will be available as \' equals() \', '
-            'and users may begin using it under this name now.',
-            DeprecationWarning, stacklevel=2)
+        # warn_once(
+        #     ' \' == \' will be deprecated after version 1.5 of ProgPy. The function will be available as \' equals() \', '
+        #     'and users may begin using it under this name now.',
+        #     DeprecationWarning, stacklevel=2)
 
         return self.equals(other)
 
@@ -176,7 +176,7 @@ class SimResult(UserList):
         Returns:
             int: Index of first sample where other occurs
         """
-        warn_once('index will be deprecated after version 1.5 of ProgPy. The function will be renamed, index_of_data, and users may begin using it under this name now.',
+        warn_once('index is deprecated. Use index_of_data instead.',
             DeprecationWarning, stacklevel=2)
 
         return self.index_of_data(other, *args, **kwargs)
@@ -221,7 +221,7 @@ class SimResult(UserList):
             dict: Element Removed
         """
         warn_once(
-            'pop will be deprecated after version 1.5 of ProgPy. The function will be renamed, pop_by_index, and users may begin using it under this name now.',
+            'pop is deprecated. Use pop_by_index instead',
             DeprecationWarning, stacklevel=2)
         return self.pop_by_index(index)
 
@@ -298,7 +298,7 @@ class SimResult(UserList):
         Returns:
             Figure
         """
-        warn_once('Behavior of SimResult.plot() will change with version 1.6. New behavior will match that of a pandas data frame.')
+        # warn_once('Behavior of SimResult.plot() will change with version 1.6. New behavior will match that of a pandas data frame.')
         return plot_timeseries(self.times, self.data, legend={'display': True}, options=kwargs)
 
     def monotonicity(self) -> Dict[str, float]:
@@ -328,11 +328,11 @@ class SimResult(UserList):
 
         # For each event, calculate monotonicity using formula
         result = {}
-        for key, l in by_event.items():
+        for key, value in by_event.items():
             mono_sum = 0
-            for i in range(len(l) - 1):
-                mono_sum += np.sign(l[i + 1] - l[i])
-            result[key] = abs(mono_sum / (len(l) - 1))
+            for i in range(len(value) - 1):
+                mono_sum += np.sign(value[i + 1] - value[i])
+            result[key] = abs(mono_sum / (len(value) - 1))
         return result
 
     def __not_implemented(self):  # lgtm [py/inheritance/signature-mismatch]

--- a/src/progpy/uncertain_data/uncertain_data.py
+++ b/src/progpy/uncertain_data/uncertain_data.py
@@ -35,7 +35,7 @@ class UncertainData(ABC):
         """
 
     @property
-    @abstractproperty
+    @abstractmethod
     def median(self) -> dict:
         """The median of the UncertainData distribution or samples 
 
@@ -49,7 +49,7 @@ class UncertainData(ABC):
         """
 
     @property
-    @abstractproperty
+    @abstractmethod
     def mean(self) -> dict:
         """The mean of the UncertainData distribution or samples 
 
@@ -63,7 +63,7 @@ class UncertainData(ABC):
         """
 
     @property
-    @abstractproperty
+    @abstractmethod
     def cov(self) -> array:
         """The covariance matrix of the UncertiantyData distribution or samples in order of keys (i.e., cov[1][1] is the standard deviation for key keys()[1])
 

--- a/src/progpy/utils/containers.py
+++ b/src/progpy/utils/containers.py
@@ -62,7 +62,7 @@ class DictLikeMatrixWrapper():
 
             Returns: numpy array
         """
-        warn('Matrix will be deprecated after version 1.5 of ProgPy. When using for matrix multiplication, please use .dot function. e.g., c.dot(np.array([1, 2, 3])).', DeprecationWarning, stacklevel=2)
+        # warn('Matrix will be deprecated after version 1.5 of ProgPy. When using for matrix multiplication, please use .dot function. e.g., c.dot(np.array([1, 2, 3])).', DeprecationWarning, stacklevel=2)
         return self._matrix
 
     @matrix.setter
@@ -86,7 +86,7 @@ class DictLikeMatrixWrapper():
         """
             Returns: frame - pd.DataFrame
         """
-        warn('frame will be deprecated after version 1.5 of ProgPy.', DeprecationWarning, stacklevel=2)
+        # warn('frame will be deprecated after version 1.5 of ProgPy.', DeprecationWarning, stacklevel=2)
         self._frame = pd.DataFrame(self._matrix.T, columns=self._keys)
         return self._frame
 
@@ -137,7 +137,7 @@ class DictLikeMatrixWrapper():
         """
         creates iterator object for the list of keys
         """
-        warn("After v1.5, iteration will iterate through values instead of keys. Please iterate through keys directly (e.g., for k in s.keys())", DeprecationWarning, stacklevel=2)
+        warn("In a future version, iteration will iterate through values instead of keys. Please iterate through keys directly (e.g., for k in s.keys())", DeprecationWarning, stacklevel=2)
         return iter(self._keys)
 
     def __len__(self) -> int:
@@ -161,14 +161,14 @@ class DictLikeMatrixWrapper():
         """
         Compares two DictLikeMatrixWrappers (i.e. *Containers) or a DictLikeMatrixWrapper and a dictionary
         """
-        warn("Behavior of '==' operator will change after version 1.5 of ProgPy. New behavior will return element wise equality as a new series. To check if two Containers are equal use container.equal(other).", DeprecationWarning)
+        warn("Behavior of '==' operator will change in a future version of ProgPy. New behavior will return element wise equality as a new series. To check if two Containers are equal use container.equals(other).", DeprecationWarning)
         return self.equals(other)
 
     def __hash__(self):
         """
         returns hash value sum for keys and matrix
         """
-        warn('hash will be deprecated after version 1.5 of ProgPy, will be replace with pandas.util.hash_pandas_object.', DeprecationWarning, stacklevel=2)
+        # warn('hash will be deprecated in a future version of ProgPy, will be replace with pandas.util.hash_pandas_object.', DeprecationWarning, stacklevel=2)
         return hash(self.keys) + hash(self._matrix)
 
     def __str__(self) -> str:
@@ -201,7 +201,7 @@ class DictLikeMatrixWrapper():
         """
         returns array of matrix values
         """
-        warn("After v1.5, values will be a property instead of a function.", DeprecationWarning, stacklevel=2)
+        # warn("After v1.5, values will be a property instead of a function.", DeprecationWarning, stacklevel=2)
         if len(self._matrix) > 0 and len(
                 self._matrix[0]) == 1:  # if the first row of the matrix has one value (i.e., non-vectorized)
             return np.array([value[0] for value in self._matrix])  # the value from the first row


### PR DESCRIPTION
Updates and refactors deprecated warnings in the codebase.

- Removes the percentage_in_bounds function from metrics/samples.py as it's deprecated.
- Comments out code related to deprecation warnings in SimResult.py to avoid redundant messages and ensure a cleaner transition.
- Modifies deprecation warnings in DictLikeMatrixWrapper to be more accurate about future behavior.
- Updates a deprecation warning message in SimResult.py to be more concise and user-friendly.

The goal is to streamline the deprecation process and provide clearer guidance to users.