### PR TITLE
Add dependency workaround for Intel-based Macs

### DIFF
--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch
 
 jobs:
-  ubuntu_test_3.9:
+  ubuntu_test_python_3_9:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
@@ -18,7 +18,7 @@ jobs:
     - name: Run tests
       run: python -m tests
 
-  ubuntu_test_3.12:
+  ubuntu_test_python_3_12:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
@@ -32,7 +32,7 @@ jobs:
     - name: Run tests
       run: python -m tests
 
-  macos_13_test_3.9:
+  macos_13_test_python_3_9:
     timeout-minutes: 30
     runs-on: macos-13
     steps:
@@ -46,7 +46,7 @@ jobs:
     - name: Run tests
       run: python -m tests
 
-  macos_13_test_3.12:
+  macos_13_test_python_3_12:
     timeout-minutes: 30
     runs-on: macos-13
     steps:
@@ -60,7 +60,7 @@ jobs:
     - name: Run tests
       run: python -m tests
 
-  macos_latest_test_3.9:
+  macos_latest_test_python_3_9:
     timeout-minutes: 30
     runs-on: macos-latest
     steps:
@@ -74,7 +74,7 @@ jobs:
     - name: Run tests
       run: python -m tests
 
-  macos_latest_test_3.12:
+  macos_latest_test_python_3_12:
     timeout-minutes: 30
     runs-on: macos-latest
     steps:
@@ -88,7 +88,7 @@ jobs:
     - name: Run tests
       run: python -m tests
 
-  windows_test_3.9:
+  windows_test_python_3_9:
     timeout-minutes: 30
     runs-on: windows-latest
     steps:
@@ -102,7 +102,7 @@ jobs:
     - name: Run tests
       run: python -m tests
 
-  windows_test_3.12:
+  windows_test_python_3_12:
     timeout-minutes: 30
     runs-on: windows-latest
     steps:

--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -4,88 +4,114 @@ on:
   workflow_dispatch
 
 jobs:
-  ubuntu_tests:
+  ubuntu_test_3.9:
     timeout-minutes: 30
-    strategy:
-      matrix:
-        python-version: ['3.9', '3.12']  # TODO: Add 3.13 when it is released
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: '3.9'
     - name: Install
       run: pip install --upgrade --upgrade-strategy eager -e '.[datadriven, test]'
     - name: Run tests
       run: python -m tests
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
-      with:
-        file: ./coverage.xml
 
-  macos_13_tests:
+  ubuntu_test_3.12:
     timeout-minutes: 30
-    strategy:
-      matrix:
-        python-version: ['3.9', '3.12']  # TODO: Add 3.13 when it is released
-        os: [macos-13]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: '3.12'
     - name: Install
       run: pip install --upgrade --upgrade-strategy eager -e '.[datadriven, test]'
     - name: Run tests
       run: python -m tests
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
-      with:
-        file: ./coverage.xml
 
-  macos_latest_tests:
+  macos_13_test_3.9:
     timeout-minutes: 30
-    strategy:
-      matrix:
-        python-version: ['3.9', '3.12']  # TODO: Add 3.13 when it is released
-        os: [macos-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: macos-13
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: '3.9'
     - name: Install
       run: pip install --upgrade --upgrade-strategy eager -e '.[datadriven, test]'
     - name: Run tests
       run: python -m tests
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
-      with:
-        file: ./coverage.xml
 
-  windows_tests:
+  macos_13_test_3.12:
     timeout-minutes: 30
-    strategy:
-      matrix:
-        python-version: ['3.9', '3.12']  # TODO: Add 3.13 when it is released
+    runs-on: macos-13
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.12'
+    - name: Install
+      run: pip install --upgrade --upgrade-strategy eager -e '.[datadriven, test]'
+    - name: Run tests
+      run: python -m tests
+
+  macos_latest_test_3.9:
+    timeout-minutes: 30
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.9'
+    - name: Install
+      run: pip install --upgrade --upgrade-strategy eager -e '.[datadriven, test]'
+    - name: Run tests
+      run: python -m tests
+
+  macos_latest_test_3.12:
+    timeout-minutes: 30
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.12'
+    - name: Install
+      run: pip install --upgrade --upgrade-strategy eager -e '.[datadriven, test]'
+    - name: Run tests
+      run: python -m tests
+
+  windows_test_3.9:
+    timeout-minutes: 30
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: '3.9'
     - name: Install
       run: pip install --upgrade --upgrade-strategy eager -e '.[datadriven, test]'
     - name: Run tests
       run: python -m tests
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+
+  windows_test_3.12:
+    timeout-minutes: 30
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
       with:
-        file: ./coverage.xml
+        python-version: '3.12'
+    - name: Install
+      run: pip install --upgrade --upgrade-strategy eager -e '.[datadriven, test]'
+    - name: Run tests
+      run: python -m tests

--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -41,7 +41,7 @@ jobs:
         file: ./coverage.xml
 
   macos_13_test_python_3_9:
-    timeout-minutes: 30
+    timeout-minutes: 45
     runs-on: macos-13
     steps:
     - uses: actions/checkout@v3
@@ -59,7 +59,7 @@ jobs:
         file: ./coverage.xml
 
   macos_13_test_python_3_12:
-    timeout-minutes: 30
+    timeout-minutes: 45
     runs-on: macos-13
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -4,13 +4,77 @@ on:
   workflow_dispatch
 
 jobs:
-  run_tests:
+  ubuntu_tests:
     timeout-minutes: 30
     strategy:
       matrix:
         python-version: ['3.9', '3.12']  # TODO: Add 3.13 when it is released
-        os: [ubuntu-latest, macos-latest, macos-13, windows-latest]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install
+      run: pip install --upgrade --upgrade-strategy eager -e '.[datadriven, test]'
+    - name: Run tests
+      run: python -m tests
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        file: ./coverage.xml
+
+  macos_13_tests:
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        python-version: ['3.9', '3.12']  # TODO: Add 3.13 when it is released
+        os: [macos-13]
     runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install
+      run: pip install --upgrade --upgrade-strategy eager -e '.[datadriven, test]'
+    - name: Run tests
+      run: python -m tests
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        file: ./coverage.xml
+
+  macos_latest_tests:
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        python-version: ['3.9', '3.12']  # TODO: Add 3.13 when it is released
+        os: [macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install
+      run: pip install --upgrade --upgrade-strategy eager -e '.[datadriven, test]'
+    - name: Run tests
+      run: python -m tests
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        file: ./coverage.xml
+
+  windows_tests:
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        python-version: ['3.9', '3.12']  # TODO: Add 3.13 when it is released
+    runs-on: windows-latest
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python

--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -4,138 +4,26 @@ on:
   workflow_dispatch
 
 jobs:
-  ubuntu_test_python_3_9:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.9'
-    - name: Installm
-      run: pip install --upgrade --upgrade-strategy eager -e '.[datadriven, test]'
-    - name: Run tests
-      run: python -m tests
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
-      with:
-        file: ./coverage.xml
-
-  ubuntu_test_python_3_12:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.12'
-    - name: Install
-      run: pip install --upgrade --upgrade-strategy eager -e '.[datadriven, test]'
-    - name: Run tests
-      run: python -m tests
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
-      with:
-        file: ./coverage.xml
-
-  macos_13_test_python_3_9:
+  run_tests:
     timeout-minutes: 45
-    runs-on: macos-13
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.9', '3.12']  # TODO: Add 3.13 when it is released
+        os: [ubuntu-latest, macos-latest, macos-13, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.9'
-    - name: Install
-      run: pip install --upgrade --upgrade-strategy eager -e '.[datadriven, test]'
-    - name: Run tests
-      run: python -m tests
-
-  macos_13_test_python_3_12:
-    timeout-minutes: 45
-    runs-on: macos-13
-    steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.12'
-    - name: Install
-      run: pip install --upgrade --upgrade-strategy eager -e '.[datadriven, test]'
-    - name: Run tests
-      run: python -m tests
-
-  macos_latest_test_python_3_9:
-    timeout-minutes: 30
-    runs-on: macos-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.9'
+        python-version: ${{ matrix.python-version }}
     - name: Install
       run: pip install --upgrade --upgrade-strategy eager -e '.[datadriven, test]'
     - name: Run tests
       run: python -m tests
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
-      with:
-        file: ./coverage.xml
-
-  macos_latest_test_python_3_12:
-    timeout-minutes: 30
-    runs-on: macos-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.12'
-    - name: Install
-      run: pip install --upgrade --upgrade-strategy eager -e '.[datadriven, test]'
-    - name: Run tests
-      run: python -m tests
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
-      with:
-        file: ./coverage.xml
-
-  windows_test_python_3_9:
-    timeout-minutes: 30
-    runs-on: windows-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.9'
-    - name: Install
-      run: pip install --upgrade --upgrade-strategy eager -e '.[datadriven, test]'
-    - name: Run tests
-      run: python -m tests
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
-      with:
-        file: ./coverage.xml
-
-  windows_test_python_3_12:
-    timeout-minutes: 30
-    runs-on: windows-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.12'
-    - name: Install
-      run: pip install --upgrade --upgrade-strategy eager -e '.[datadriven, test]'
-    - name: Run tests
-      run: python -m tests
-    - name: Upload coverage to Codecov
+      if: ${{ matrix.python-version }} == '3.12' && ${{ matrix.os }} == 'ubuntu-latest'
       uses: codecov/codecov-action@v3
       with:
         file: ./coverage.xml

--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -13,10 +13,14 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: '3.9'
-    - name: Install
+    - name: Installm
       run: pip install --upgrade --upgrade-strategy eager -e '.[datadriven, test]'
     - name: Run tests
       run: python -m tests
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        file: ./coverage.xml
 
   ubuntu_test_python_3_12:
     timeout-minutes: 30
@@ -31,6 +35,10 @@ jobs:
       run: pip install --upgrade --upgrade-strategy eager -e '.[datadriven, test]'
     - name: Run tests
       run: python -m tests
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        file: ./coverage.xml
 
   macos_13_test_python_3_9:
     timeout-minutes: 30
@@ -45,6 +53,10 @@ jobs:
       run: pip install --upgrade --upgrade-strategy eager -e '.[datadriven, test]'
     - name: Run tests
       run: python -m tests
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        file: ./coverage.xml
 
   macos_13_test_python_3_12:
     timeout-minutes: 30
@@ -59,6 +71,10 @@ jobs:
       run: pip install --upgrade --upgrade-strategy eager -e '.[datadriven, test]'
     - name: Run tests
       run: python -m tests
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        file: ./coverage.xml
 
   macos_latest_test_python_3_9:
     timeout-minutes: 30
@@ -73,6 +89,10 @@ jobs:
       run: pip install --upgrade --upgrade-strategy eager -e '.[datadriven, test]'
     - name: Run tests
       run: python -m tests
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        file: ./coverage.xml
 
   macos_latest_test_python_3_12:
     timeout-minutes: 30
@@ -87,6 +107,10 @@ jobs:
       run: pip install --upgrade --upgrade-strategy eager -e '.[datadriven, test]'
     - name: Run tests
       run: python -m tests
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        file: ./coverage.xml
 
   windows_test_python_3_9:
     timeout-minutes: 30
@@ -101,6 +125,10 @@ jobs:
       run: pip install --upgrade --upgrade-strategy eager -e '.[datadriven, test]'
     - name: Run tests
       run: python -m tests
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        file: ./coverage.xml
 
   windows_test_python_3_12:
     timeout-minutes: 30
@@ -115,3 +143,7 @@ jobs:
       run: pip install --upgrade --upgrade-strategy eager -e '.[datadriven, test]'
     - name: Run tests
       run: python -m tests
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        file: ./coverage.xml

--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -53,10 +53,6 @@ jobs:
       run: pip install --upgrade --upgrade-strategy eager -e '.[datadriven, test]'
     - name: Run tests
       run: python -m tests
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
-      with:
-        file: ./coverage.xml
 
   macos_13_test_python_3_12:
     timeout-minutes: 45
@@ -71,10 +67,6 @@ jobs:
       run: pip install --upgrade --upgrade-strategy eager -e '.[datadriven, test]'
     - name: Run tests
       run: python -m tests
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
-      with:
-        file: ./coverage.xml
 
   macos_latest_test_python_3_9:
     timeout-minutes: 30

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,8 +55,16 @@ classifiers = [
 
 [project.optional-dependencies]
 datadriven = [
-    "tensorflow>=2.18.0",   # Note that older versions of tensorflow may work with older numpy and numpoly versions
-    "chaospy>=4.3.17"   # For PCE
+    # Dependency workaround for Intel-based Macs due to tensorflow version constraints at 2.16.2
+    "tensorflow==2.16.2; platform_system == 'Darwin' and platform_machine != 'arm64'",
+    "numpy==1.26.4; platform_system == 'Darwin' and platform_machine != 'arm64'",
+    "numpoly==1.2.12; platform_system == 'Darwin' and platform_machine != 'arm64'",
+
+    # Everything else (non-Intel macOS, Linux, Windows, etc.) Note that older versions of tensorflow may work with older numpy and numpoly versions
+    "tensorflow>=2.18.0; platform_system != 'Darwin' or platform_machine == 'arm64'",
+
+    # For PCE
+    "chaospy>=4.3.17"
 ]
 
 test = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ datadriven = [
     "numpy==1.26.4; platform_system == 'Darwin' and platform_machine != 'arm64'",
     "numpoly==1.2.12; platform_system == 'Darwin' and platform_machine != 'arm64'",
 
-    # Everything else (non-Intel macOS, Linux, Windows, etc.) Note that older versions of tensorflow may work with older numpy and numpoly versions
+    # Everything else (Apple Silicon Macs, Linux, Windows, etc.) Note that older versions of tensorflow may work with older numpy and numpoly versions
     "tensorflow>=2.18.0; platform_system != 'Darwin' or platform_machine == 'arm64'",
 
     # For PCE

--- a/tests/test_tutorials.py
+++ b/tests/test_tutorials.py
@@ -10,7 +10,7 @@ sys.path.append(join(dirname(__file__), ".."))
 
 class TestTutorials(unittest.TestCase):
     def run_notebook_test(self, notebook_path):
-        with testbook(notebook_path, execute=True) as tb:
+        with testbook(notebook_path, execute=True, timeout=1200) as tb:
             self.assertEqual(tb.__class__.__name__, "TestbookNotebookClient")
 
     def test_notebook_tutorials(self):


### PR DESCRIPTION
**NOTE:** *This is a backup option in case the transition from `tensorflow` to `PyTorch` doesn't work*

`tensorflow` is needed to enable data-driven features in Progpy. However, we need a dependency workaround using an older version of `tensorflow` at `2.16.2` since newer versions like `2.18.0` are not available for Intel-based Macs. Older versions of `tensorflow` may have issues with newer versions of `numpy` and `numpoly`.

The workaround thus includes a know working combination of of `tensorflow==2.16.2`, `numpy==1.26.4`, and `numpoly==1.2.12`.

More information on `tensorflow` support, refer to https://github.com/tensorflow/tensorflow/issues/78836